### PR TITLE
Add price to items

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <application
         android:name=".SharingangApplication"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"

--- a/app/src/main/java/com/example/sharingang/EditItemFragment.kt
+++ b/app/src/main/java/com/example/sharingang/EditItemFragment.kt
@@ -35,7 +35,11 @@ class EditItemFragment : Fragment() {
         binding.editItemButton.setOnClickListener { view: View ->
             viewModel.updateItem(
                 item,
-                Item(title = binding.title ?: "", description = binding.description ?: "", price = binding.price?.toDoubleOrNull() ?: 0.0)
+                Item(
+                    title = binding.title ?: "",
+                    description = binding.description ?: "",
+                    price = binding.price?.toDoubleOrNull() ?: 0.0
+                )
 
             )
             view.findNavController().navigate(R.id.action_editItemFragment_to_itemsListFragment)

--- a/app/src/main/java/com/example/sharingang/EditItemFragment.kt
+++ b/app/src/main/java/com/example/sharingang/EditItemFragment.kt
@@ -30,11 +30,12 @@ class EditItemFragment : Fragment() {
 
         binding.title = item.title
         binding.description = item.description
+        binding.price = item.price
 
         binding.editItemButton.setOnClickListener { view: View ->
             viewModel.updateItem(
                 item,
-                Item(title = binding.title ?: "", description = binding.description ?: "")
+                Item(title = binding.title ?: "", description = binding.description ?: "", price = binding.price)
             )
             view.findNavController().navigate(R.id.action_editItemFragment_to_itemsListFragment)
         }

--- a/app/src/main/java/com/example/sharingang/EditItemFragment.kt
+++ b/app/src/main/java/com/example/sharingang/EditItemFragment.kt
@@ -30,12 +30,13 @@ class EditItemFragment : Fragment() {
 
         binding.title = item.title
         binding.description = item.description
-        binding.price = item.price
+        binding.price = item.price.toString().format("%.2f")
 
         binding.editItemButton.setOnClickListener { view: View ->
             viewModel.updateItem(
                 item,
-                Item(title = binding.title ?: "", description = binding.description ?: "", price = binding.price)
+                Item(title = binding.title ?: "", description = binding.description ?: "", price = binding.price?.toDoubleOrNull() ?: 0.0)
+
             )
             view.findNavController().navigate(R.id.action_editItemFragment_to_itemsListFragment)
         }

--- a/app/src/main/java/com/example/sharingang/NewItemFragment.kt
+++ b/app/src/main/java/com/example/sharingang/NewItemFragment.kt
@@ -29,7 +29,7 @@ class NewItemFragment : Fragment() {
                 Item(
                     description = binding.description ?: "",
                     title = binding.title ?: "",
-                    price = binding.price
+                    price = binding.price?.toDoubleOrNull() ?: 0.0
 
                 )
             )

--- a/app/src/main/java/com/example/sharingang/NewItemFragment.kt
+++ b/app/src/main/java/com/example/sharingang/NewItemFragment.kt
@@ -28,7 +28,9 @@ class NewItemFragment : Fragment() {
             viewModel.addItem(
                 Item(
                     description = binding.description ?: "",
-                    title = binding.title ?: ""
+                    title = binding.title ?: "",
+                    price = binding.price
+
                 )
             )
             view.findNavController().navigate(R.id.action_newItemFragment_to_itemsListFragment)

--- a/app/src/main/java/com/example/sharingang/NewItemFragment.kt
+++ b/app/src/main/java/com/example/sharingang/NewItemFragment.kt
@@ -27,10 +27,9 @@ class NewItemFragment : Fragment() {
         binding.createItemButton.setOnClickListener { view: View ->
             viewModel.addItem(
                 Item(
+                    price = binding.price?.toDoubleOrNull() ?: 0.0,
                     description = binding.description ?: "",
-                    title = binding.title ?: "",
-                    price = binding.price?.toDoubleOrNull() ?: 0.0
-
+                    title = binding.title ?: ""
                 )
             )
             view.findNavController().navigate(R.id.action_newItemFragment_to_itemsListFragment)

--- a/app/src/main/java/com/example/sharingang/items/Item.kt
+++ b/app/src/main/java/com/example/sharingang/items/Item.kt
@@ -19,7 +19,7 @@ data class Item(
     val images: List<String> = listOf(),
 
     /** Price in cents */
-    val price: Int = 0,
+    val price: Double = 0.0,
 
     val createdAt: Date = Date(),
 

--- a/app/src/main/java/com/example/sharingang/items/Item.kt
+++ b/app/src/main/java/com/example/sharingang/items/Item.kt
@@ -18,7 +18,6 @@ data class Item(
     /** URLs of the images */
     val images: List<String> = listOf(),
 
-    /** Price in cents */
     val price: Double = 0.0,
 
     val createdAt: Date = Date(),

--- a/app/src/main/res/layout/fragment_edit_item.xml
+++ b/app/src/main/res/layout/fragment_edit_item.xml
@@ -10,6 +10,9 @@
         <variable
             name="description"
             type="String" />
+        <variable
+            name="price"
+            type="double" />
     </data>
 
     <LinearLayout
@@ -44,8 +47,18 @@
             android:importantForAutofill="no"
             android:inputType="textMultiLine"
             android:minLines="4"
-            android:singleLine="false"
-            android:text="@={description}" />
+            android:text="@={description}"
+            android:singleLine="false" />
+
+        <EditText
+            android:id="@+id/editItemPrice"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:ems="10"
+            android:hint="@string/price"
+            android:inputType="numberDecimal"
+            android:importantForAutofill="no"
+            android:text="@={price}"/>
 
         <Button
             android:id="@+id/editItemButton"

--- a/app/src/main/res/layout/fragment_edit_item.xml
+++ b/app/src/main/res/layout/fragment_edit_item.xml
@@ -12,7 +12,7 @@
             type="String" />
         <variable
             name="price"
-            type="double" />
+            type="String" />
     </data>
 
     <LinearLayout

--- a/app/src/main/res/layout/fragment_new_item.xml
+++ b/app/src/main/res/layout/fragment_new_item.xml
@@ -12,7 +12,7 @@
             type="String" />
         <variable
             name="price"
-            type="double" />
+            type="String" />
     </data>
 
     <LinearLayout
@@ -53,13 +53,14 @@
 
         <EditText
             android:id="@+id/editItemPrice"
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:autofillHints="yes"
             android:ems="10"
             android:hint="@string/default_price"
             android:importantForAutofill="yes"
-            android:autofillHints="yes"
-            android:inputType="numberDecimal" />
+            android:inputType="numberDecimal"
+            android:text="@={price}" />
 
         <Button
             android:id="@+id/createItemButton"

--- a/app/src/main/res/layout/fragment_new_item.xml
+++ b/app/src/main/res/layout/fragment_new_item.xml
@@ -10,6 +10,9 @@
         <variable
             name="description"
             type="String" />
+        <variable
+            name="price"
+            type="double" />
     </data>
 
     <LinearLayout
@@ -47,6 +50,16 @@
             android:singleLine="false"
             android:text="@={description}"
             tools:ignore="LabelFor" />
+
+        <EditText
+            android:id="@+id/editItemPrice"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:ems="10"
+            android:hint="@string/default_price"
+            android:importantForAutofill="yes"
+            android:autofillHints="yes"
+            android:inputType="numberDecimal" />
 
         <Button
             android:id="@+id/createItemButton"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,4 +8,6 @@
     <string name="edit">Edit</string>
     <string name="edit_item">Edit Item</string>
     <string name="title">Title</string>
+    <string name="default_price">Price (default: 0.0)</string>
+    <string name="price">Price</string>
 </resources>


### PR DESCRIPTION
Prices can now be added to items when creating or editing them. If the user does not enter a price, it is set to 0.0 by default. When a user sets a price and then edits the item, the previous price is displayed when editing it. 

![Webp net-resizeimage](https://user-images.githubusercontent.com/45470351/111172551-34183880-85a6-11eb-9271-bf1141252dbf.png)  ![Webp net-resizeimage (1)](https://user-images.githubusercontent.com/45470351/111172578-3bd7dd00-85a6-11eb-8ddc-2f97393508c7.png)




