### PR TITLE
59 display items

### DIFF
--- a/app/src/androidTest/java/com/example/sharingang/MapFragmentTest.kt
+++ b/app/src/androidTest/java/com/example/sharingang/MapFragmentTest.kt
@@ -9,7 +9,10 @@ import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import androidx.test.rule.GrantPermissionRule
+import androidx.test.uiautomator.UiDevice
+import androidx.test.uiautomator.UiSelector
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.hamcrest.core.StringContains.containsString
@@ -34,19 +37,16 @@ class MapFragmentTest {
     @Test
     fun itemsAddedAreDisplayedOnTheMap() {
         onView(withId(R.id.newItemButton)).perform(click())
-        onView(withId(R.id.write_latitude)).perform(
-            ViewActions.typeText("37.4"),
-            ViewActions.closeSoftKeyboard()
-        )
-        onView(withId(R.id.write_longitude)).perform(
-            ViewActions.typeText("4.143"),
-            ViewActions.closeSoftKeyboard()
-        )
+        onView(withId(R.id.new_item_get_location)).perform(click())
+        Thread.sleep(3000)
         onView(withId(R.id.createItemButton)).perform(click())
         onView(withId(R.id.go_to_map)).perform(click())
         val text = onView(withId(R.id.location_display))
         //text.check(matches(withText("")))
         Thread.sleep(6000)
         text.check(matches(withText(containsString("Your location"))))
+        val device = UiDevice.getInstance(getInstrumentation())
+        val marker = device.findObject(UiSelector().descriptionContains(""))
+        marker.click()
     }
 }

--- a/app/src/androidTest/java/com/example/sharingang/MapFragmentTest.kt
+++ b/app/src/androidTest/java/com/example/sharingang/MapFragmentTest.kt
@@ -2,6 +2,7 @@ package com.example.sharingang
 
 import android.Manifest
 import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.withId
@@ -31,10 +32,20 @@ class MapFragmentTest {
         GrantPermissionRule.grant(Manifest.permission.ACCESS_FINE_LOCATION)
 
     @Test
-    fun openingFragmentDisplaysLocation() {
+    fun itemsAddedAreDisplayedOnTheMap() {
+        onView(withId(R.id.newItemButton)).perform(click())
+        onView(withId(R.id.write_latitude)).perform(
+            ViewActions.typeText("37.4"),
+            ViewActions.closeSoftKeyboard()
+        )
+        onView(withId(R.id.write_longitude)).perform(
+            ViewActions.typeText("4.143"),
+            ViewActions.closeSoftKeyboard()
+        )
+        onView(withId(R.id.createItemButton)).perform(click())
         onView(withId(R.id.go_to_map)).perform(click())
         val text = onView(withId(R.id.location_display))
-        text.check(matches(withText("")))
+        //text.check(matches(withText("")))
         Thread.sleep(6000)
         text.check(matches(withText(containsString("Your location"))))
     }

--- a/app/src/main/java/com/example/sharingang/MapFragment.kt
+++ b/app/src/main/java/com/example/sharingang/MapFragment.kt
@@ -125,7 +125,7 @@ class MapFragment : Fragment(), OnMapReadyCallback {
         map?.setOnMarkerClickListener { marker: Marker ->
             if (marker != lastLocationMarker) {
                 val temp: Item = marker.tag as Item
-                Toast.makeText(context, "$temp is required", Toast.LENGTH_SHORT).show()
+                Toast.makeText(context, "$temp", Toast.LENGTH_SHORT).show()
             }
             map?.animateCamera(CameraUpdateFactory.newLatLng(marker.position))
             true

--- a/app/src/main/java/com/example/sharingang/MapFragment.kt
+++ b/app/src/main/java/com/example/sharingang/MapFragment.kt
@@ -61,6 +61,13 @@ class MapFragment : Fragment(), OnMapReadyCallback {
                 moveLastLocationMarker()
             }
         }
+        setupItemsMarkers()
+        binding.mapView.onCreate(savedInstanceState)
+        binding.mapView.getMapAsync(this)
+        return binding.root
+    }
+
+    private fun setupItemsMarkers(){
         viewModel.items.observe(viewLifecycleOwner, {
             for (item: Item in it) {
                 val addedMarker = map?.addMarker(
@@ -70,9 +77,6 @@ class MapFragment : Fragment(), OnMapReadyCallback {
                 addedMarker?.tag = item
             }
         })
-        binding.mapView.onCreate(savedInstanceState)
-        binding.mapView.getMapAsync(this)
-        return binding.root
     }
 
     @SuppressLint("MissingPermission")

--- a/app/src/main/java/com/example/sharingang/MapFragment.kt
+++ b/app/src/main/java/com/example/sharingang/MapFragment.kt
@@ -67,7 +67,7 @@ class MapFragment : Fragment(), OnMapReadyCallback {
         return binding.root
     }
 
-    private fun setupItemsMarkers(){
+    private fun setupItemsMarkers() {
         viewModel.items.observe(viewLifecycleOwner, {
             for (item: Item in it) {
                 val addedMarker = map?.addMarker(

--- a/app/src/main/java/com/example/sharingang/MapFragment.kt
+++ b/app/src/main/java/com/example/sharingang/MapFragment.kt
@@ -69,6 +69,10 @@ class MapFragment : Fragment(), OnMapReadyCallback {
 
     private fun setupItemsMarkers() {
         viewModel.items.observe(viewLifecycleOwner, {
+            map?.clear() // need to remove all markers, otherwise they will be added once more on the map, stacking them up
+            if (lastLocation != null) {
+                addLastLocationMarker()
+            }
             for (item: Item in it) {
                 val addedMarker = map?.addMarker(
                     MarkerOptions().position(LatLng(item.latitude, item.longitude))
@@ -95,8 +99,8 @@ class MapFragment : Fragment(), OnMapReadyCallback {
     private fun updateLocationText() {
         binding.locationDisplay.text = String.format(
             "Your location is: %s %s",
-            lastLocation!!.longitude,
-            lastLocation!!.latitude
+            lastLocation!!.latitude,
+            lastLocation!!.longitude
         )
     }
 
@@ -114,6 +118,10 @@ class MapFragment : Fragment(), OnMapReadyCallback {
 
     private fun moveLastLocationMarker() {
         lastLocationMarker?.remove()
+        addLastLocationMarker()
+    }
+
+    private fun addLastLocationMarker() {
         lastLocationMarker = map?.addMarker(
             MarkerOptions().position(
                 LatLng(

--- a/app/src/main/res/layout/fragment_edit_item.xml
+++ b/app/src/main/res/layout/fragment_edit_item.xml
@@ -95,7 +95,7 @@
                 android:autofillHints="no"
                 android:ems="10"
                 android:hint="@string/latitude"
-                android:inputType="numberDecimal"
+                android:inputType="numberDecimal|numberSigned"
                 android:text="@={latitude}" />
 
             <EditText
@@ -106,7 +106,7 @@
                 android:autofillHints="no"
                 android:ems="10"
                 android:hint="@string/longitude"
-                android:inputType="numberDecimal"
+                android:inputType="numberDecimal|numberSigned"
                 android:text="@={longitude}" />
         </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_new_item.xml
+++ b/app/src/main/res/layout/fragment_new_item.xml
@@ -97,7 +97,7 @@
                 android:autofillHints="no"
                 android:ems="10"
                 android:hint="@string/latitude"
-                android:inputType="numberDecimal"
+                android:inputType="numberDecimal|numberSigned"
                 android:text="@={latitude}"/>
 
             <EditText
@@ -108,7 +108,7 @@
                 android:autofillHints="no"
                 android:ems="10"
                 android:hint="@string/longitude"
-                android:inputType="numberDecimal"
+                android:inputType="numberDecimal|numberSigned"
                 android:text="@={longitude}"/>
         </LinearLayout>
 


### PR DESCRIPTION
Fix #59 
I added a way to display the items on the map (in red, the current location of the user, in blue, the items location). 
<img width="319" alt="before_click" src="https://user-images.githubusercontent.com/61214027/113193555-61c8d700-9260-11eb-858f-6aaeafdf9ba2.png">
For the moment, it displays all the items currently stored, but we could filter the items by distance, or by category, for example.

After clicking on an item marker, a description of the item appears on screen. 
<img width="317" alt="after_click" src="https://user-images.githubusercontent.com/61214027/113193796-a94f6300-9260-11eb-9001-ea517fc3cafa.png">

We could display a full description of the items instead, like when clicking on an item on the main page.