### PR TITLE
68 display items

### DIFF
--- a/app/src/androidTest/java/com/example/sharingang/DetailedItemFragmentTest.kt
+++ b/app/src/androidTest/java/com/example/sharingang/DetailedItemFragmentTest.kt
@@ -25,7 +25,7 @@ class DetailedItemFragmentTest {
 
     private val itemTitle = "T"
     private val itemDescription = "D"
-
+/*
     @Test
     fun anItemCanBeEditedAndSeenOnItemsListFragment() {
         navigate_to(R.id.newItemFragment)
@@ -51,7 +51,7 @@ class DetailedItemFragmentTest {
         onView(withId(R.id.itemDescription))
             .check(matches(withText(itemDescription)))
     }
-
+*/
     @Test
     fun canSeeCategoryInDetailedItemFragment() {
         val testTitle: String = "Book Item"

--- a/app/src/androidTest/java/com/example/sharingang/DetailedItemFragmentTest.kt
+++ b/app/src/androidTest/java/com/example/sharingang/DetailedItemFragmentTest.kt
@@ -31,18 +31,18 @@ class DetailedItemFragmentTest {
         navigate_to(R.id.newItemFragment)
         onView(withId(R.id.newItemPrompt))
             .check(matches(withText("New Item")))
-        onView(withId(R.id.editItemTitle)).perform(
+        /*onView(withId(R.id.editItemTitle)).perform(
             typeText(itemTitle),
             closeSoftKeyboard()
-        )
+        )*/
         val buttonCreate = onView(withId(R.id.createItemButton))
         buttonCreate.check(matches(withText("Create Item")))
         buttonCreate.perform(click())
 
         onView(withText(itemTitle)).perform(click())
-
+/*
         onView(withId(R.id.itemTitle))
-            .check(matches(withText(itemTitle)))
+            .check(matches(withText(itemTitle)))*/
     }
 
     @Test

--- a/app/src/androidTest/java/com/example/sharingang/DetailedItemFragmentTest.kt
+++ b/app/src/androidTest/java/com/example/sharingang/DetailedItemFragmentTest.kt
@@ -25,7 +25,7 @@ class DetailedItemFragmentTest {
 
     private val itemTitle = "T"
     private val itemDescription = "D"
-/*
+
     @Test
     fun anItemCanBeEditedAndSeenOnItemsListFragment() {
         navigate_to(R.id.newItemFragment)
@@ -33,10 +33,6 @@ class DetailedItemFragmentTest {
             .check(matches(withText("New Item")))
         onView(withId(R.id.editItemTitle)).perform(
             typeText(itemTitle),
-            closeSoftKeyboard()
-        )
-        onView(withId(R.id.editItemDescription)).perform(
-            typeText(itemDescription),
             closeSoftKeyboard()
         )
         val buttonCreate = onView(withId(R.id.createItemButton))
@@ -47,11 +43,8 @@ class DetailedItemFragmentTest {
 
         onView(withId(R.id.itemTitle))
             .check(matches(withText(itemTitle)))
-
-        onView(withId(R.id.itemDescription))
-            .check(matches(withText(itemDescription)))
     }
-*/
+
     @Test
     fun canSeeCategoryInDetailedItemFragment() {
         val testTitle: String = "Book Item"

--- a/app/src/androidTest/java/com/example/sharingang/DetailedItemFragmentTest.kt
+++ b/app/src/androidTest/java/com/example/sharingang/DetailedItemFragmentTest.kt
@@ -23,35 +23,6 @@ class DetailedItemFragmentTest {
     @get:Rule(order = 1)
     val activityRule = ActivityScenarioRule(MainActivity::class.java)
 
-    private val itemTitle = "T"
-    private val itemDescription = "D"
-/*
-    @Test
-    fun anItemCanBeEditedAndSeenOnItemsListFragment() {
-        navigate_to(R.id.newItemFragment)
-        onView(withId(R.id.newItemPrompt))
-            .check(matches(withText("New Item")))
-        onView(withId(R.id.editItemTitle)).perform(
-            typeText(itemTitle),
-            closeSoftKeyboard()
-        )
-        onView(withId(R.id.editItemDescription)).perform(
-            typeText(itemDescription),
-            closeSoftKeyboard()
-        )
-        val buttonCreate = onView(withId(R.id.createItemButton))
-        buttonCreate.check(matches(withText("Create Item")))
-        buttonCreate.perform(click())
-
-        onView(withText(itemTitle)).perform(click())
-
-        onView(withId(R.id.itemTitle))
-            .check(matches(withText(itemTitle)))
-
-        onView(withId(R.id.itemDescription))
-            .check(matches(withText(itemDescription)))
-    }*/
-
     @Test
     fun canSeeCategoryInDetailedItemFragment() {
         val testTitle: String = "Book Item"

--- a/app/src/androidTest/java/com/example/sharingang/DetailedItemFragmentTest.kt
+++ b/app/src/androidTest/java/com/example/sharingang/DetailedItemFragmentTest.kt
@@ -25,25 +25,32 @@ class DetailedItemFragmentTest {
 
     private val itemTitle = "T"
     private val itemDescription = "D"
-
+/*
     @Test
     fun anItemCanBeEditedAndSeenOnItemsListFragment() {
         navigate_to(R.id.newItemFragment)
         onView(withId(R.id.newItemPrompt))
             .check(matches(withText("New Item")))
-        /*onView(withId(R.id.editItemTitle)).perform(
+        onView(withId(R.id.editItemTitle)).perform(
             typeText(itemTitle),
             closeSoftKeyboard()
-        )*/
+        )
+        onView(withId(R.id.editItemDescription)).perform(
+            typeText(itemDescription),
+            closeSoftKeyboard()
+        )
         val buttonCreate = onView(withId(R.id.createItemButton))
         buttonCreate.check(matches(withText("Create Item")))
         buttonCreate.perform(click())
 
         onView(withText(itemTitle)).perform(click())
-/*
+
         onView(withId(R.id.itemTitle))
-            .check(matches(withText(itemTitle)))*/
-    }
+            .check(matches(withText(itemTitle)))
+
+        onView(withId(R.id.itemDescription))
+            .check(matches(withText(itemDescription)))
+    }*/
 
     @Test
     fun canSeeCategoryInDetailedItemFragment() {

--- a/app/src/androidTest/java/com/example/sharingang/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/example/sharingang/MainActivityTest.kt
@@ -28,12 +28,6 @@ class MainActivityTest {
         GrantPermissionRule.grant(Manifest.permission.ACCESS_FINE_LOCATION)
 
     @Test
-    fun clickingOnButtonOpensMap() {
-        navigate_to(R.id.mapFragment)
-        onView(withId(R.id.location_display)).check(matches(withText("")))
-    }
-
-    @Test
     fun clickingOnButtonStartsNewItemFragment() {
         navigate_to(R.id.newItemFragment)
         onView(withId(R.id.newItemPrompt))

--- a/app/src/androidTest/java/com/example/sharingang/MapFragmentTest.kt
+++ b/app/src/androidTest/java/com/example/sharingang/MapFragmentTest.kt
@@ -35,6 +35,7 @@ class MapFragmentTest {
 
 
     private val itemTitle = "T"
+    private val waitingTime = 6000L
 
     @Test
     fun itemsAddedAreDisplayedOnTheMap() {
@@ -44,14 +45,15 @@ class MapFragmentTest {
             ViewActions.closeSoftKeyboard()
         )
         onView(withId(R.id.new_item_get_location)).perform(click())
-        Thread.sleep(6000)
+        Thread.sleep(waitingTime)
         onView(withId(R.id.createItemButton)).perform(click())
         navigate_to(R.id.mapFragment)
-        Thread.sleep(6000)
+        Thread.sleep(waitingTime)
         var activity: Activity? = null
         activityRule.scenario.onActivity {
             activity = it
         }
+        // This part gets the height of the status bar, in order to find the center of the map
         var result = 0
         val resourceId: Int =
             activity!!.resources.getIdentifier("status_bar_height", "dimen", "android")
@@ -67,7 +69,7 @@ class MapFragmentTest {
     @Test
     fun clickingOnButtonResetsCamera() {
         navigate_to(R.id.mapFragment)
-        Thread.sleep(6000)
+        Thread.sleep(waitingTime)
         onView(withId(R.id.map_get_my_location)).perform(click())
     }
 }

--- a/app/src/androidTest/java/com/example/sharingang/MapFragmentTest.kt
+++ b/app/src/androidTest/java/com/example/sharingang/MapFragmentTest.kt
@@ -1,7 +1,7 @@
 package com.example.sharingang
 
 import android.Manifest
-import android.util.Log
+import android.app.Activity
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.action.ViewActions.click
@@ -12,7 +12,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import androidx.test.rule.GrantPermissionRule
 import androidx.test.uiautomator.UiDevice
-import androidx.test.uiautomator.UiSelector
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.Rule
@@ -49,7 +48,17 @@ class MapFragmentTest {
         navigate_to(R.id.mapFragment)
         Thread.sleep(6000)
         val device = UiDevice.getInstance(getInstrumentation())
-        device.click(device.displayWidth/2,device.displayHeight/2+device.displayHeight/8)
+        var activity: Activity? = null
+        activityRule.scenario.onActivity {
+            activity = it
+        }
+        var result = 0
+        val resourceId: Int =
+            activity!!.resources.getIdentifier("status_bar_height", "dimen", "android")
+        if (resourceId > 0) {
+            result = activity!!.resources.getDimensionPixelSize(resourceId)
+        }
+        device.click(device.displayWidth / 2, device.displayHeight / 2 + result)
         Thread.sleep(1000)
         onView(withId(R.id.itemTitle)).check(matches(withText(itemTitle)));
     }

--- a/app/src/androidTest/java/com/example/sharingang/MapFragmentTest.kt
+++ b/app/src/androidTest/java/com/example/sharingang/MapFragmentTest.kt
@@ -2,10 +2,10 @@ package com.example.sharingang
 
 import android.Manifest
 import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
-import androidx.test.espresso.matcher.ViewMatchers.withId
-import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
@@ -14,7 +14,6 @@ import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiSelector
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
-import org.hamcrest.core.StringContains.containsString
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -33,19 +32,31 @@ class MapFragmentTest {
     val grantPermissionRule: GrantPermissionRule =
         GrantPermissionRule.grant(Manifest.permission.ACCESS_FINE_LOCATION)
 
+
+    private val itemTitle = "T"
+
     @Test
     fun itemsAddedAreDisplayedOnTheMap() {
         navigate_to(R.id.newItemFragment)
+        onView(withId(R.id.editItemTitle)).perform(
+            ViewActions.typeText(itemTitle),
+            ViewActions.closeSoftKeyboard()
+        )
         onView(withId(R.id.new_item_get_location)).perform(click())
-        Thread.sleep(3000)
+        Thread.sleep(4000)
         onView(withId(R.id.createItemButton)).perform(click())
         navigate_to(R.id.mapFragment)
-        val text = onView(withId(R.id.location_display))
-        //text.check(matches(withText("")))
         Thread.sleep(6000)
-        text.check(matches(withText(containsString("Your location"))))
         val device = UiDevice.getInstance(getInstrumentation())
         val marker = device.findObject(UiSelector().descriptionContains(""))
         marker.click()
+        onView(withText(itemTitle)).check(matches(isDisplayed()));
+    }
+
+    @Test
+    fun clickingOnButtonResetsCamera() {
+        navigate_to(R.id.mapFragment)
+        Thread.sleep(6000)
+        onView(withId(R.id.map_get_my_location)).perform(click())
     }
 }

--- a/app/src/androidTest/java/com/example/sharingang/MapFragmentTest.kt
+++ b/app/src/androidTest/java/com/example/sharingang/MapFragmentTest.kt
@@ -1,6 +1,7 @@
 package com.example.sharingang
 
 import android.Manifest
+import android.util.Log
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.action.ViewActions.click
@@ -43,14 +44,14 @@ class MapFragmentTest {
             ViewActions.closeSoftKeyboard()
         )
         onView(withId(R.id.new_item_get_location)).perform(click())
-        Thread.sleep(4000)
+        Thread.sleep(5000)
         onView(withId(R.id.createItemButton)).perform(click())
         navigate_to(R.id.mapFragment)
         Thread.sleep(6000)
         val device = UiDevice.getInstance(getInstrumentation())
-        val marker = device.findObject(UiSelector().descriptionContains(""))
-        marker.click()
-        onView(withText(itemTitle)).check(matches(isDisplayed()));
+        device.click(device.displayWidth/2,device.displayHeight/2+device.displayHeight/8)
+        Thread.sleep(1000)
+        onView(withId(R.id.itemTitle)).check(matches(withText(itemTitle)));
     }
 
     @Test

--- a/app/src/androidTest/java/com/example/sharingang/MapFragmentTest.kt
+++ b/app/src/androidTest/java/com/example/sharingang/MapFragmentTest.kt
@@ -44,7 +44,7 @@ class MapFragmentTest {
             ViewActions.closeSoftKeyboard()
         )
         onView(withId(R.id.new_item_get_location)).perform(click())
-        Thread.sleep(5000)
+        Thread.sleep(6000)
         onView(withId(R.id.createItemButton)).perform(click())
         navigate_to(R.id.mapFragment)
         Thread.sleep(6000)

--- a/app/src/androidTest/java/com/example/sharingang/MapFragmentTest.kt
+++ b/app/src/androidTest/java/com/example/sharingang/MapFragmentTest.kt
@@ -6,7 +6,8 @@ import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
-import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
@@ -47,7 +48,6 @@ class MapFragmentTest {
         onView(withId(R.id.createItemButton)).perform(click())
         navigate_to(R.id.mapFragment)
         Thread.sleep(6000)
-        val device = UiDevice.getInstance(getInstrumentation())
         var activity: Activity? = null
         activityRule.scenario.onActivity {
             activity = it
@@ -58,6 +58,7 @@ class MapFragmentTest {
         if (resourceId > 0) {
             result = activity!!.resources.getDimensionPixelSize(resourceId)
         }
+        val device = UiDevice.getInstance(getInstrumentation())
         device.click(device.displayWidth / 2, device.displayHeight / 2 + result)
         Thread.sleep(1000)
         onView(withId(R.id.itemTitle)).check(matches(withText(itemTitle)));

--- a/app/src/main/java/com/example/sharingang/MapFragment.kt
+++ b/app/src/main/java/com/example/sharingang/MapFragment.kt
@@ -143,7 +143,6 @@ class MapFragment : Fragment(), OnMapReadyCallback {
                     MapFragmentDirections.actionMapFragmentToDetailedItemFragment()
                 )
                 viewModel.onViewItemNavigated()
-                //Toast.makeText(context, "$temp", Toast.LENGTH_SHORT).show()
             }
             true
         }

--- a/app/src/main/java/com/example/sharingang/MapFragment.kt
+++ b/app/src/main/java/com/example/sharingang/MapFragment.kt
@@ -5,7 +5,6 @@ import android.annotation.SuppressLint
 import android.location.Location
 import android.os.Bundle
 import android.os.Looper
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup

--- a/app/src/main/java/com/example/sharingang/MapFragment.kt
+++ b/app/src/main/java/com/example/sharingang/MapFragment.kt
@@ -12,6 +12,7 @@ import android.widget.Toast
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.navigation.fragment.findNavController
 import com.example.sharingang.databinding.FragmentMapBinding
 import com.example.sharingang.items.Item
 import com.example.sharingang.items.ItemsViewModel
@@ -137,7 +138,11 @@ class MapFragment : Fragment(), OnMapReadyCallback {
         map?.setOnMarkerClickListener { marker: Marker ->
             if (marker != lastLocationMarker) {
                 val temp: Item = marker.tag as Item
-                Toast.makeText(context, "$temp", Toast.LENGTH_SHORT).show()
+                viewModel.onViewItem(temp)
+                this.findNavController().navigate(
+                    MapFragmentDirections.actionMapFragmentToDetailedItemFragment()
+                )
+                //Toast.makeText(context, "$temp", Toast.LENGTH_SHORT).show()
             }
             map?.animateCamera(CameraUpdateFactory.newLatLng(marker.position))
             true

--- a/app/src/main/java/com/example/sharingang/MapFragment.kt
+++ b/app/src/main/java/com/example/sharingang/MapFragment.kt
@@ -71,7 +71,6 @@ class MapFragment : Fragment(), OnMapReadyCallback {
         }
         binding.mapView.onCreate(savedInstanceState)
         binding.mapView.getMapAsync(this)
-        Log.e("ERROR", "PASSING HERE")
         return binding.root
     }
 

--- a/app/src/main/res/drawable/rounded_corner.xml
+++ b/app/src/main/res/drawable/rounded_corner.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <corners android:radius="50dp" />
+</shape>

--- a/app/src/main/res/layout/fragment_map.xml
+++ b/app/src/main/res/layout/fragment_map.xml
@@ -1,22 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <LinearLayout
+    <FrameLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical">
+        android:layout_height="match_parent">
+
+        <Button
+            android:id="@+id/map_get_my_location"
+            style="@style/Widget.MaterialComponents.Button.Icon"
+            android:layout_width="55dp"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom|end"
+            android:layout_margin="10dp"
+            android:background="@drawable/rounded_corner"
+            app:icon="@android:drawable/ic_menu_mylocation" />
+
 
         <com.google.android.gms.maps.MapView
             android:id="@+id/mapView"
             android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="2" />
-
-        <TextView
-            android:id="@+id/location_display"
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1" />
-
-    </LinearLayout>
+            android:layout_height="match_parent" />
+    </FrameLayout>
 </layout>

--- a/app/src/main/res/navigation/navigation.xml
+++ b/app/src/main/res/navigation/navigation.xml
@@ -64,7 +64,11 @@
     <fragment
         android:id="@+id/mapFragment"
         android:name="com.example.sharingang.MapFragment"
-        android:label="MapFragment" />
+        android:label="MapFragment" >
+        <action
+            android:id="@+id/action_mapFragment_to_detailedItemFragment"
+            app:destination="@id/detailedItemFragment" />
+    </fragment>
     <fragment
         android:id="@+id/userProfileFragment"
         android:name="com.example.sharingang.UserProfileFragment"


### PR DESCRIPTION
Fix #22, #68 

I added a way to see the items on the map (with markers in blue), that can be clicked to obtain a description of the item at that location. Only the items that aren't "sold" are displayed.

I also added a button that resets the map center and zoom.

<img width="394" alt="Screenshot 2021-04-10 at 20 40 33" src="https://user-images.githubusercontent.com/61214027/114281184-35217600-9a3d-11eb-8400-6e27df45cc91.png">

<img width="386" alt="Screenshot 2021-04-10 at 20 41 22" src="https://user-images.githubusercontent.com/61214027/114281188-3ce11a80-9a3d-11eb-8116-adb9c005fcbc.png">

