### PR TITLE
Fix bug that crashed the app when denying twice the permission request

### DIFF
--- a/app/src/main/java/com/example/sharingang/MapFragment.kt
+++ b/app/src/main/java/com/example/sharingang/MapFragment.kt
@@ -70,6 +70,12 @@ class MapFragment : Fragment(), OnMapReadyCallback {
         }
         binding.mapView.onCreate(savedInstanceState)
         binding.mapView.getMapAsync(this)
+        doOrGetPermission(
+            this,
+            Manifest.permission.ACCESS_FINE_LOCATION,
+            { startLocationUpdates() },
+            requestPermissionLauncher
+        )
         return binding.root
     }
 
@@ -148,12 +154,6 @@ class MapFragment : Fragment(), OnMapReadyCallback {
 
     override fun onResume() {
         binding.mapView.onResume()
-        doOrGetPermission(
-            this,
-            Manifest.permission.ACCESS_FINE_LOCATION,
-            { startLocationUpdates() },
-            requestPermissionLauncher
-        )
         super.onResume()
     }
 

--- a/app/src/main/java/com/example/sharingang/MapFragment.kt
+++ b/app/src/main/java/com/example/sharingang/MapFragment.kt
@@ -70,12 +70,6 @@ class MapFragment : Fragment(), OnMapReadyCallback {
         }
         binding.mapView.onCreate(savedInstanceState)
         binding.mapView.getMapAsync(this)
-        doOrGetPermission(
-            this,
-            Manifest.permission.ACCESS_FINE_LOCATION,
-            { startLocationUpdates() },
-            requestPermissionLauncher
-        )
         return binding.root
     }
 
@@ -150,6 +144,12 @@ class MapFragment : Fragment(), OnMapReadyCallback {
             }
             true
         }
+        doOrGetPermission(
+            this,
+            Manifest.permission.ACCESS_FINE_LOCATION,
+            { startLocationUpdates() },
+            requestPermissionLauncher
+        )
     }
 
     override fun onResume() {


### PR DESCRIPTION
Fix #117 
Just a quick fix for the map feature: when denying the permission twice, it would slow down the app so much, making it unusable. The problem came from onResume, that was called every time the permission request window was shown, basically asking for permission endlessly.