### PR TITLE
98 address translation

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -58,6 +58,7 @@ dependencies {
     // Location
     implementation 'com.google.android.gms:play-services-location:18.0.0'
     implementation 'com.google.android.gms:play-services-maps:17.0.0'
+    implementation 'com.google.android.libraries.places:places:2.4.0'
 
     // Navigation Component
     implementation "androidx.navigation:navigation-fragment-ktx:$navigationVersion"

--- a/app/src/androidTest/java/com/example/sharingang/EditItemFragmentTest.kt
+++ b/app/src/androidTest/java/com/example/sharingang/EditItemFragmentTest.kt
@@ -5,9 +5,7 @@ import android.provider.MediaStore
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.*
 import androidx.test.espresso.assertion.ViewAssertions.matches
-import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.Intents.intending
-import androidx.test.espresso.intent.matcher.IntentMatchers
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
 import androidx.test.espresso.intent.rule.IntentsTestRule
 import androidx.test.espresso.matcher.ViewMatchers.*
@@ -16,7 +14,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.GrantPermissionRule
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
-import org.hamcrest.Matchers
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/app/src/androidTest/java/com/example/sharingang/EditItemFragmentTest.kt
+++ b/app/src/androidTest/java/com/example/sharingang/EditItemFragmentTest.kt
@@ -146,15 +146,4 @@ class EditItemFragmentTest {
         onView(withId(R.id.new_item_take_picture)).perform(click())
         onView(withId(R.id.new_item_image)).check(matches(hasContentDescription()))
     }
-
-    @Test
-    fun clickingOnGetLocationDisplaysLocation() {
-        navigate_to(R.id.newItemFragment)
-        val button = onView(withId(R.id.new_item_get_location))
-        button.check(matches(withText("Get Location")))
-        button.perform(click())
-        Thread.sleep(5000)
-        onView(withId(R.id.write_latitude)).check(matches(Matchers.not(withText(""))))
-        onView(withId(R.id.write_longitude)).check(matches(Matchers.not(withText(""))))
-    }
 }

--- a/app/src/androidTest/java/com/example/sharingang/NewItemFragmentTest.kt
+++ b/app/src/androidTest/java/com/example/sharingang/NewItemFragmentTest.kt
@@ -1,8 +1,8 @@
 package com.example.sharingang
 
 import android.Manifest
-import android.provider.MediaStore
 import android.content.Intent
+import android.provider.MediaStore
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.*
 import androidx.test.espresso.assertion.ViewAssertions.matches
@@ -12,9 +12,12 @@ import androidx.test.espresso.intent.rule.IntentsTestRule
 import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.GrantPermissionRule
+import androidx.test.uiautomator.UiDevice
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
+import org.hamcrest.Matchers.containsString
 import org.hamcrest.Matchers.not
 import org.junit.Rule
 import org.junit.Test
@@ -73,7 +76,8 @@ class NewItemFragmentTest {
     fun anImageCanBeChosenFromGallery() {
         savePickedImage(mActivityTestRule.activity)
         val imgGalleryResult = createImageGallerySetResultStub(mActivityTestRule.activity)
-        Intents.intending(IntentMatchers.hasAction(Intent.ACTION_GET_CONTENT)).respondWith(imgGalleryResult)
+        Intents.intending(IntentMatchers.hasAction(Intent.ACTION_GET_CONTENT))
+            .respondWith(imgGalleryResult)
 
         navigate_to(R.id.newItemFragment)
         onView(withId(R.id.newItemPrompt)).check(matches(withText("New Item")))
@@ -86,7 +90,8 @@ class NewItemFragmentTest {
     fun aPictureCanBeTakenAndDisplayed() {
         savePickedImage(mActivityTestRule.activity)
         val imgGalleryResult = createImageGallerySetResultStub(mActivityTestRule.activity)
-        Intents.intending(IntentMatchers.hasAction(MediaStore.ACTION_IMAGE_CAPTURE)).respondWith(imgGalleryResult)
+        Intents.intending(IntentMatchers.hasAction(MediaStore.ACTION_IMAGE_CAPTURE))
+            .respondWith(imgGalleryResult)
 
         navigate_to(R.id.newItemFragment)
         onView(withId(R.id.newItemPrompt)).check(matches(withText("New Item")))
@@ -102,21 +107,18 @@ class NewItemFragmentTest {
         button.check(matches(withText("Get Location")))
         button.perform(click())
         Thread.sleep(5000)
-        onView(withId(R.id.write_latitude)).check(matches(not(withText(""))))
-        onView(withId(R.id.write_longitude)).check(matches(not(withText(""))))
+        onView(withId(R.id.postal_address)).check(matches(not(withText(""))))
     }
 
     @Test
-    fun aLocationCanBeWrittenInNewItemFragment() {
+    fun aLocationCanBeSetInNewItemFragment() {
         navigate_to(R.id.newItemFragment)
-        onView(withId(R.id.write_latitude)).perform(
-            typeText("45.01"),
-            closeSoftKeyboard()
-        )
-        onView(withId(R.id.write_longitude)).perform(
-            typeText("5.014"),
-            closeSoftKeyboard()
-        )
-        onView(withId(R.id.createItemButton)).perform(click())
+        onView(withId(R.id.autocomplete_fragment)).perform(click())
+        onView(withHint("Enter Address")).perform(typeText("Taj"), closeSoftKeyboard())
+        Thread.sleep(3000)
+        val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+        device.click(device.displayWidth / 2, device.displayHeight / 2)
+        Thread.sleep(3000)
+        onView(withId(R.id.postal_address)).check(matches(withText(containsString("Taj"))))
     }
 }

--- a/app/src/androidTest/java/com/example/sharingang/NewItemFragmentTest.kt
+++ b/app/src/androidTest/java/com/example/sharingang/NewItemFragmentTest.kt
@@ -121,4 +121,14 @@ class NewItemFragmentTest {
         Thread.sleep(3000)
         onView(withId(R.id.postal_address)).check(matches(withText(containsString("Taj"))))
     }
+
+    @Test
+    fun addressSearchCanBeCanceled(){
+        navigate_to(R.id.newItemFragment)
+        onView(withId(R.id.autocomplete_fragment)).perform(click())
+        val device = UiDevice.getInstance((InstrumentationRegistry.getInstrumentation()))
+        device.pressBack()
+        device.pressBack()
+        onView(withId(R.id.postal_address)).check(matches(withText("")))
+    }
 }

--- a/app/src/main/java/com/example/sharingang/NewItemFragment.kt
+++ b/app/src/main/java/com/example/sharingang/NewItemFragment.kt
@@ -165,6 +165,6 @@ class NewItemFragment : Fragment() {
         binding.longitude = location.longitude.toString()
         val address =
             geocoder.getFromLocation(location.latitude, location.longitude, 1).getOrNull(0)
-        binding.postalAddress.text = address?.getAddressLine(0)
+        binding.postalAddress.text = if(address!=null) address.getAddressLine(0) else ""
     }
 }

--- a/app/src/main/java/com/example/sharingang/NewItemFragment.kt
+++ b/app/src/main/java/com/example/sharingang/NewItemFragment.kt
@@ -165,6 +165,6 @@ class NewItemFragment : Fragment() {
         binding.longitude = location.longitude.toString()
         val address =
             geocoder.getFromLocation(location.latitude, location.longitude, 1).getOrNull(0)
-        binding.postalAddress.text = if(address!=null) address.getAddressLine(0) else ""
+        binding.postalAddress.text = address?.getAddressLine(0) ?: ""
     }
 }

--- a/app/src/main/java/com/example/sharingang/NewItemFragment.kt
+++ b/app/src/main/java/com/example/sharingang/NewItemFragment.kt
@@ -115,18 +115,7 @@ class NewItemFragment : Fragment() {
         binding.createItemButton.setOnClickListener { view: View ->
             imageUri = observer.getImageUri()
             viewModel.addItem(
-                Item(
-                    price = binding.price?.toDoubleOrNull() ?: 0.0,
-                    description = binding.description ?: "",
-                    title = binding.title ?: "",
-                    category = binding.categorySpinner.selectedItemPosition,
-                    categoryString = resources.getStringArray(R.array.categories)[binding.categorySpinner.selectedItemPosition],
-                    latitude = binding.latitude?.toDoubleOrNull() ?: 0.0,
-                    longitude = binding.longitude?.toDoubleOrNull() ?: 0.0,
-                    sold = false,
-                    imageUri = imageUri?.toString(),
-                    userId = userId
-                )
+                itemToAdd()
             )
             observer.unregister()
             view.findNavController().navigate(R.id.action_newItemFragment_to_itemsListFragment)
@@ -137,6 +126,21 @@ class NewItemFragment : Fragment() {
         binding.newItemTakePicture.setOnClickListener {
             observer.openCamera()
         }
+    }
+
+    private fun itemToAdd(): Item {
+        return Item(
+            price = binding.price?.toDoubleOrNull() ?: 0.0,
+            description = binding.description ?: "",
+            title = binding.title ?: "",
+            category = binding.categorySpinner.selectedItemPosition,
+            categoryString = resources.getStringArray(R.array.categories)[binding.categorySpinner.selectedItemPosition],
+            latitude = binding.latitude?.toDoubleOrNull() ?: 0.0,
+            longitude = binding.longitude?.toDoubleOrNull() ?: 0.0,
+            sold = false,
+            imageUri = imageUri?.toString(),
+            userId = userId
+        )
     }
 
     private fun setupLocationCreate() {

--- a/app/src/main/java/com/example/sharingang/NewItemFragment.kt
+++ b/app/src/main/java/com/example/sharingang/NewItemFragment.kt
@@ -1,10 +1,9 @@
 package com.example.sharingang
 
-import android.net.Uri
 import android.Manifest
-import android.location.Address
 import android.location.Geocoder
 import android.location.Location
+import android.net.Uri
 import android.os.Bundle
 import android.util.Log
 import android.view.LayoutInflater
@@ -14,7 +13,6 @@ import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.findNavController
-import androidx.navigation.fragment.findNavController
 import com.example.sharingang.databinding.FragmentNewItemBinding
 import com.example.sharingang.items.Item
 import com.example.sharingang.items.ItemsViewModel
@@ -26,19 +24,14 @@ import com.example.sharingang.utils.requestPermissionLauncher
 import com.google.android.gms.common.api.Status
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
-import com.google.android.gms.maps.model.LatLng
-import com.google.android.gms.maps.model.LatLngBounds
 import com.google.android.gms.tasks.CancellationTokenSource
 import com.google.android.libraries.places.api.Places
 import com.google.android.libraries.places.api.model.Place
-import com.google.android.libraries.places.api.model.RectangularBounds
 import com.google.android.libraries.places.api.model.TypeFilter
 import com.google.android.libraries.places.widget.AutocompleteSupportFragment
 import com.google.android.libraries.places.widget.listener.PlaceSelectionListener
 import dagger.hilt.android.AndroidEntryPoint
-import java.util.*
 import javax.inject.Inject
-import kotlin.concurrent.schedule
 
 @AndroidEntryPoint
 class NewItemFragment : Fragment() {
@@ -57,6 +50,7 @@ class NewItemFragment : Fragment() {
 
     private lateinit var fusedLocationCreate: FusedLocationProviderClient
     private lateinit var geocoder: Geocoder
+
     // Allows the cancellation of a location request if, for example, the user exists the activity
     private var cancellationTokenSource = CancellationTokenSource()
     private val requestPermissionLauncher = requestPermissionLauncher(this) {
@@ -93,24 +87,26 @@ class NewItemFragment : Fragment() {
         return binding.root
     }
 
-    private fun setupAutocomplete(){
+    private fun setupAutocomplete() {
         geocoder = Geocoder(requireContext())
-        if(!Places.isInitialized()){
-            Places.initialize(requireContext(),getString(R.string.google_api_key))
+        if (!Places.isInitialized()) {
+            Places.initialize(requireContext(), getString(R.string.google_api_key))
         }
-        val autocompleteSupportFragment = childFragmentManager.findFragmentById(R.id.autocomplete_fragment) as AutocompleteSupportFragment
+        val autocompleteSupportFragment =
+            childFragmentManager.findFragmentById(R.id.autocomplete_fragment) as AutocompleteSupportFragment
         autocompleteSupportFragment.setHint(getString(R.string.enter_address))
         autocompleteSupportFragment.setTypeFilter(TypeFilter.ADDRESS)
         autocompleteSupportFragment.setPlaceFields(listOf(Place.Field.ADDRESS))
-        autocompleteSupportFragment.setOnPlaceSelectedListener(object:PlaceSelectionListener{
+        autocompleteSupportFragment.setOnPlaceSelectedListener(object : PlaceSelectionListener {
             override fun onPlaceSelected(place: Place) {
                 binding.postalAddress.text = place.address
-                val address = geocoder.getFromLocationName(place.address,1).getOrNull(0)
+                val address = geocoder.getFromLocationName(place.address, 1).getOrNull(0)
                 binding.latitude = address?.latitude.toString()
                 binding.longitude = address?.longitude.toString()
             }
+
             override fun onError(status: Status) {
-                Log.e("Error","$status")
+                Log.e("Error", "$status")
             }
         })
     }
@@ -118,18 +114,20 @@ class NewItemFragment : Fragment() {
     private fun bind() {
         binding.createItemButton.setOnClickListener { view: View ->
             imageUri = observer.getImageUri()
-            viewModel.addItem(Item(
-                price = binding.price?.toDoubleOrNull() ?: 0.0,
-                description = binding.description ?: "",
-                title = binding.title ?: "",
-                category = binding.categorySpinner.selectedItemPosition,
-                categoryString = resources.getStringArray(R.array.categories)[binding.categorySpinner.selectedItemPosition],
-                latitude = binding.latitude?.toDoubleOrNull() ?: 0.0,
-                longitude = binding.longitude?.toDoubleOrNull() ?: 0.0,
-                sold = false,
-                imageUri = imageUri?.toString(),
-                userId = userId
-            ))
+            viewModel.addItem(
+                Item(
+                    price = binding.price?.toDoubleOrNull() ?: 0.0,
+                    description = binding.description ?: "",
+                    title = binding.title ?: "",
+                    category = binding.categorySpinner.selectedItemPosition,
+                    categoryString = resources.getStringArray(R.array.categories)[binding.categorySpinner.selectedItemPosition],
+                    latitude = binding.latitude?.toDoubleOrNull() ?: 0.0,
+                    longitude = binding.longitude?.toDoubleOrNull() ?: 0.0,
+                    sold = false,
+                    imageUri = imageUri?.toString(),
+                    userId = userId
+                )
+            )
             observer.unregister()
             view.findNavController().navigate(R.id.action_newItemFragment_to_itemsListFragment)
         }
@@ -161,7 +159,8 @@ class NewItemFragment : Fragment() {
     private fun updateLocation(location: Location) {
         binding.latitude = location.latitude.toString()
         binding.longitude = location.longitude.toString()
-        val address = geocoder.getFromLocation(location.latitude,location.longitude,1).getOrNull(0)
+        val address =
+            geocoder.getFromLocation(location.latitude, location.longitude, 1).getOrNull(0)
         binding.postalAddress.text = address?.getAddressLine(0)
     }
 }

--- a/app/src/main/res/layout/fragment_new_item.xml
+++ b/app/src/main/res/layout/fragment_new_item.xml
@@ -51,7 +51,7 @@
                 android:contentDescription="@string/item_image_description"
                 android:src="@drawable/ic_baseline_image_24" />
 
-            <ImageView
+            <ImageButton
                 android:id="@+id/new_item_take_picture"
                 android:layout_width="match_parent"
                 android:layout_height="70dp"

--- a/app/src/main/res/layout/fragment_new_item.xml
+++ b/app/src/main/res/layout/fragment_new_item.xml
@@ -15,9 +15,11 @@
         <variable
             name="price"
             type="String" />
+
         <variable
             name="latitude"
             type="String" />
+
         <variable
             name="longitude"
             type="String" />
@@ -44,16 +46,16 @@
             <ImageView
                 android:id="@+id/new_item_image"
                 android:layout_width="match_parent"
-                android:layout_weight="1"
                 android:layout_height="70dp"
+                android:layout_weight="1"
                 android:contentDescription="@string/item_image_description"
                 android:src="@drawable/ic_baseline_image_24" />
 
             <ImageView
                 android:id="@+id/new_item_take_picture"
                 android:layout_width="match_parent"
-                android:layout_weight="1"
                 android:layout_height="70dp"
+                android:layout_weight="1"
                 android:contentDescription="@string/item_image_description"
                 android:src="@android:drawable/ic_menu_camera" />
         </LinearLayout>
@@ -98,10 +100,12 @@
             android:importantForAutofill="yes"
             android:inputType="numberDecimal"
             android:text="@={price}" />
-        <androidx.fragment.app.FragmentContainerView android:id="@+id/autocomplete_fragment"
+
+        <androidx.fragment.app.FragmentContainerView
+            android:id="@+id/autocomplete_fragment"
+            android:name="com.google.android.libraries.places.widget.AutocompleteSupportFragment"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:name="com.google.android.libraries.places.widget.AutocompleteSupportFragment" >
+            android:layout_height="wrap_content">
 
         </androidx.fragment.app.FragmentContainerView>
 

--- a/app/src/main/res/layout/fragment_new_item.xml
+++ b/app/src/main/res/layout/fragment_new_item.xml
@@ -36,18 +36,27 @@
             android:textSize="30sp"
             android:textStyle="bold" />
 
-        <ImageView
-            android:id="@+id/new_item_image"
+        <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="150dp"
-            android:contentDescription="@string/item_image_description"
-            android:src="@drawable/ic_baseline_image_24" />
-
-        <Button
-            android:id="@+id/new_item_take_picture"
-            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/take_picture" />
+            android:orientation="horizontal">
+
+            <ImageView
+                android:id="@+id/new_item_image"
+                android:layout_width="match_parent"
+                android:layout_weight="1"
+                android:layout_height="70dp"
+                android:contentDescription="@string/item_image_description"
+                android:src="@drawable/ic_baseline_image_24" />
+
+            <ImageView
+                android:id="@+id/new_item_take_picture"
+                android:layout_width="match_parent"
+                android:layout_weight="1"
+                android:layout_height="70dp"
+                android:contentDescription="@string/item_image_description"
+                android:src="@android:drawable/ic_menu_camera" />
+        </LinearLayout>
 
         <EditText
             android:id="@+id/editItemTitle"
@@ -89,34 +98,18 @@
             android:importantForAutofill="yes"
             android:inputType="numberDecimal"
             android:text="@={price}" />
-
-        <LinearLayout
+        <androidx.fragment.app.FragmentContainerView android:id="@+id/autocomplete_fragment"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="horizontal">
+            android:name="com.google.android.libraries.places.widget.AutocompleteSupportFragment" >
 
-            <EditText
-                android:id="@+id/write_latitude"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:autofillHints="no"
-                android:ems="10"
-                android:hint="@string/latitude"
-                android:inputType="numberDecimal|numberSigned"
-                android:text="@={latitude}"/>
+        </androidx.fragment.app.FragmentContainerView>
 
-            <EditText
-                android:id="@+id/write_longitude"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:autofillHints="no"
-                android:ems="10"
-                android:hint="@string/longitude"
-                android:inputType="numberDecimal|numberSigned"
-                android:text="@={longitude}"/>
-        </LinearLayout>
+        <TextView
+            android:id="@+id/postal_address"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="" />
 
         <Button
             android:id="@+id/new_item_get_location"

--- a/app/src/main/res/layout/fragment_new_item.xml
+++ b/app/src/main/res/layout/fragment_new_item.xml
@@ -38,19 +38,27 @@
             android:textSize="30sp"
             android:textStyle="bold" />
 
-        <ImageView
-            android:id="@+id/new_item_image"
-            android:layout_width="match_parent"
-            android:layout_height="150dp"
-            android:contentDescription="@string/item_image_description"
-            android:src="@drawable/ic_baseline_image_24" />
-
-        <ImageButton
-            android:id="@+id/new_item_take_picture"
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:contentDescription="@string/item_image_description"
-            android:src="@android:drawable/ic_menu_camera" />
+            android:orientation="horizontal">
+
+            <ImageView
+                android:id="@+id/new_item_image"
+                android:layout_width="match_parent"
+                android:layout_height="120dp"
+                android:layout_weight="2"
+                android:contentDescription="@string/item_image_description"
+                android:src="@drawable/ic_baseline_image_24" />
+
+            <ImageButton
+                android:id="@+id/new_item_take_picture"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="2"
+                android:contentDescription="@string/item_image_description"
+                android:src="@android:drawable/ic_menu_camera" />
+        </LinearLayout>
 
         <EditText
             android:id="@+id/editItemTitle"
@@ -70,7 +78,7 @@
             android:hint="@string/description"
             android:importantForAutofill="no"
             android:inputType="textMultiLine"
-            android:minLines="4"
+            android:minLines="3"
             android:singleLine="false"
             android:text="@={description}"
             tools:ignore="LabelFor" />

--- a/app/src/main/res/layout/fragment_new_item.xml
+++ b/app/src/main/res/layout/fragment_new_item.xml
@@ -38,27 +38,19 @@
             android:textSize="30sp"
             android:textStyle="bold" />
 
-        <LinearLayout
+        <ImageView
+            android:id="@+id/new_item_image"
+            android:layout_width="match_parent"
+            android:layout_height="150dp"
+            android:contentDescription="@string/item_image_description"
+            android:src="@drawable/ic_baseline_image_24" />
+
+        <ImageButton
+            android:id="@+id/new_item_take_picture"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="horizontal">
-
-            <ImageView
-                android:id="@+id/new_item_image"
-                android:layout_width="match_parent"
-                android:layout_height="70dp"
-                android:layout_weight="1"
-                android:contentDescription="@string/item_image_description"
-                android:src="@drawable/ic_baseline_image_24" />
-
-            <ImageButton
-                android:id="@+id/new_item_take_picture"
-                android:layout_width="match_parent"
-                android:layout_height="70dp"
-                android:layout_weight="1"
-                android:contentDescription="@string/item_image_description"
-                android:src="@android:drawable/ic_menu_camera" />
-        </LinearLayout>
+            android:contentDescription="@string/item_image_description"
+            android:src="@android:drawable/ic_menu_camera" />
 
         <EditText
             android:id="@+id/editItemTitle"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,6 +28,7 @@
     <string name="clear_search_button">Clear search</string>
     <string name="share">Share</string>
     <string name="take_picture">Take Picture</string>
+    <string name="enter_address">Enter Address</string>
     <string-array name="categories">
         <item>None</item>
         <item>Book</item>


### PR DESCRIPTION
Fix #98, #116 
I implemented a way to add addresses to items instead of geographic coordinates.

<img width="376" alt="Screenshot 2021-04-17 at 20 19 33" src="https://user-images.githubusercontent.com/61214027/115122869-8b9d3000-9fba-11eb-9b07-d21c8bdace44.png">
<img width="377" alt="Screenshot 2021-04-17 at 20 19 49" src="https://user-images.githubusercontent.com/61214027/115122870-8cce5d00-9fba-11eb-89cd-313b98ee8fa8.png">
<img width="375" alt="Screenshot 2021-04-17 at 20 20 04" src="https://user-images.githubusercontent.com/61214027/115122872-8dff8a00-9fba-11eb-85a0-ea769d4f7250.png">

A user can still use the button "Get Location", which will give an approximate address of the user, if possible (meaning that if the user is in the middle of the ocean, there won't be any address, but the coordinates will still be saved).

I also refactored the image icons and the design of new fragment, so that they take less space.

I didn't change EditFragment yet because I am planning on merging EditItemFragment and NewItemFragment in my next PR.