### PR TITLE
Make map use searches

### DIFF
--- a/app/src/androidTest/java/com/example/sharingang/MapFragmentTest.kt
+++ b/app/src/androidTest/java/com/example/sharingang/MapFragmentTest.kt
@@ -48,6 +48,14 @@ class MapFragmentTest {
         Thread.sleep(waitingTime)
         onView(withId(R.id.createItemButton)).perform(click())
         navigate_to(R.id.mapFragment)
+        onView(withId(R.id.map_start_search)).perform(click())
+        onView(withId(R.id.searchText)).perform(
+            ViewActions.typeText(itemTitle),
+            ViewActions.closeSoftKeyboard()
+        )
+        onView(withId(R.id.sflSearchButton)).perform(click())
+        navigate_up()
+        onView(withId(R.id.map_get_my_location)).perform(click())
         Thread.sleep(waitingTime)
         var activity: Activity? = null
         activityRule.scenario.onActivity {
@@ -63,7 +71,7 @@ class MapFragmentTest {
         val device = UiDevice.getInstance(getInstrumentation())
         device.click(device.displayWidth / 2, device.displayHeight / 2 + result)
         Thread.sleep(1000)
-        onView(withId(R.id.itemTitle)).check(matches(withText(itemTitle)));
+        onView(withId(R.id.itemTitle)).check(matches(withText(itemTitle)))
     }
 
     @Test

--- a/app/src/androidTest/java/com/example/sharingang/navigation_util.kt
+++ b/app/src/androidTest/java/com/example/sharingang/navigation_util.kt
@@ -55,3 +55,23 @@ fun navigate_to(id: Int) {
     )
     navigationMenuItemView.perform(ViewActions.click())
 }
+
+fun navigate_up() {
+    val appCompatImageButton2 = Espresso.onView(
+        Matchers.allOf(
+            ViewMatchers.withContentDescription("Navigate up"),
+            childAtPosition(
+                Matchers.allOf(
+                    ViewMatchers.withId(R.id.toolbar),
+                    childAtPosition(
+                        ViewMatchers.withClassName(Matchers.`is`("android.widget.LinearLayout")),
+                        0
+                    )
+                ),
+                1
+            ),
+            ViewMatchers.isDisplayed()
+        )
+    )
+    appCompatImageButton2.perform(ViewActions.click())
+}

--- a/app/src/main/java/com/example/sharingang/MapFragment.kt
+++ b/app/src/main/java/com/example/sharingang/MapFragment.kt
@@ -39,12 +39,22 @@ class MapFragment : Fragment(), OnMapReadyCallback {
         )
     }
     private var lastLocation: Location? = null
-    private lateinit var locationCallback: LocationCallback
+    private val locationCallback: LocationCallback = object : LocationCallback() {
+        override fun onLocationResult(locationResult: LocationResult) {
+            lastLocation = locationResult.lastLocation
+            if (!hasCameraMovedOnce) {
+                moveCameraToLastLocation()
+                hasCameraMovedOnce = true
+            }
+            moveLastLocationMarker()
+        }
+    }
     private var lastLocationMarker: Marker? = null
     private var map: GoogleMap? = null
 
     private val viewModel: ItemsViewModel by activityViewModels()
     private var hasCameraMovedOnce by Delegates.notNull<Boolean>()
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -53,16 +63,6 @@ class MapFragment : Fragment(), OnMapReadyCallback {
         binding = DataBindingUtil.inflate(inflater, R.layout.fragment_map, container, false)
         fusedLocationClient = LocationServices.getFusedLocationProviderClient(requireContext())
         hasCameraMovedOnce = false
-        locationCallback = object : LocationCallback() {
-            override fun onLocationResult(locationResult: LocationResult) {
-                lastLocation = locationResult.lastLocation
-                if (!hasCameraMovedOnce) {
-                    moveCameraToLastLocation()
-                    hasCameraMovedOnce = true
-                }
-                moveLastLocationMarker()
-            }
-        }
         viewModel.searchResults.observe(viewLifecycleOwner, {
             addItemMarkers(it)
         })

--- a/app/src/main/java/com/example/sharingang/MapFragment.kt
+++ b/app/src/main/java/com/example/sharingang/MapFragment.kt
@@ -68,6 +68,10 @@ class MapFragment : Fragment(), OnMapReadyCallback {
                 moveCameraToLastLocation()
             }
         }
+        binding.mapStartSearch.setOnClickListener {
+            this.findNavController()
+                .navigate(MapFragmentDirections.actionMapFragmentToSearchFragment())
+        }
         binding.mapView.onCreate(savedInstanceState)
         binding.mapView.getMapAsync(this)
         return binding.root

--- a/app/src/main/java/com/example/sharingang/MapFragment.kt
+++ b/app/src/main/java/com/example/sharingang/MapFragment.kt
@@ -5,7 +5,6 @@ import android.annotation.SuppressLint
 import android.location.Location
 import android.os.Bundle
 import android.os.Looper
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup

--- a/app/src/main/java/com/example/sharingang/MapFragment.kt
+++ b/app/src/main/java/com/example/sharingang/MapFragment.kt
@@ -74,7 +74,7 @@ class MapFragment : Fragment(), OnMapReadyCallback {
     }
 
     private fun setupItemsMarkers() {
-        viewModel.items.observe(viewLifecycleOwner, {
+        viewModel.searchResults.observe(viewLifecycleOwner, {
             map?.clear() // need to remove all markers, otherwise they will be added once more on the map, stacking them up
             if (lastLocation != null) {
                 addLastLocationMarker()

--- a/app/src/main/res/layout/fragment_map.xml
+++ b/app/src/main/res/layout/fragment_map.xml
@@ -6,20 +6,35 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <Button
-            android:id="@+id/map_get_my_location"
-            style="@style/Widget.MaterialComponents.Button.Icon"
-            android:layout_width="55dp"
-            android:layout_height="wrap_content"
-            android:layout_gravity="bottom|end"
-            android:layout_margin="10dp"
-            android:background="@drawable/rounded_corner"
-            app:icon="@android:drawable/ic_menu_mylocation" />
-
 
         <com.google.android.gms.maps.MapView
             android:id="@+id/mapView"
             android:layout_width="match_parent"
             android:layout_height="match_parent" />
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom|end"
+            android:orientation="vertical"
+            android:layout_margin="10dp">
+
+            <Button
+                android:id="@+id/map_get_my_location"
+                style="@style/Widget.MaterialComponents.Button.Icon"
+                android:layout_width="55dp"
+                android:layout_height="wrap_content"
+                android:background="@drawable/rounded_corner"
+                app:icon="@android:drawable/ic_menu_mylocation" />
+
+            <Button
+                android:id="@+id/map_start_search"
+                style="@style/Widget.MaterialComponents.Button.Icon"
+                android:layout_width="55dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp"
+                android:background="@drawable/rounded_corner"
+                app:icon="@android:drawable/ic_menu_search" />
+        </LinearLayout>
     </FrameLayout>
 </layout>

--- a/app/src/main/res/layout/fragment_map.xml
+++ b/app/src/main/res/layout/fragment_map.xml
@@ -16,16 +16,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="bottom|end"
-            android:orientation="vertical"
-            android:layout_margin="10dp">
-
-            <Button
-                android:id="@+id/map_get_my_location"
-                style="@style/Widget.MaterialComponents.Button.Icon"
-                android:layout_width="55dp"
-                android:layout_height="wrap_content"
-                android:background="@drawable/rounded_corner"
-                app:icon="@android:drawable/ic_menu_mylocation" />
+            android:layout_margin="10dp"
+            android:orientation="vertical">
 
             <Button
                 android:id="@+id/map_start_search"
@@ -35,6 +27,16 @@
                 android:layout_marginTop="10dp"
                 android:background="@drawable/rounded_corner"
                 app:icon="@android:drawable/ic_menu_search" />
+
+            <Button
+                android:id="@+id/map_get_my_location"
+                style="@style/Widget.MaterialComponents.Button.Icon"
+                android:layout_width="55dp"
+                android:layout_height="wrap_content"
+                android:background="@drawable/rounded_corner"
+                app:icon="@android:drawable/ic_menu_mylocation" />
+
+
         </LinearLayout>
     </FrameLayout>
 </layout>

--- a/app/src/main/res/navigation/navigation.xml
+++ b/app/src/main/res/navigation/navigation.xml
@@ -75,6 +75,9 @@
         <action
             android:id="@+id/action_mapFragment_to_detailedItemFragment"
             app:destination="@id/detailedItemFragment" />
+        <action
+            android:id="@+id/action_mapFragment_to_searchFragment"
+            app:destination="@id/searchFragment" />
     </fragment>
     <fragment
         android:id="@+id/userProfileFragment"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/22821947/115359440-f7e88100-a1be-11eb-8170-47015e82973f.png)
Fixes #128
Fixes #121 

This makes the map use the search results, instead of displaying all items. To make searching more convenient, I've also added a button to go from the map to the search fragment. This would be even more convenient if the map remembered your position, but that's for another story.