### PR TITLE
Hide edit and sell buttons if not your item

### DIFF
--- a/app/src/main/java/com/example/sharingang/ItemsListFragment.kt
+++ b/app/src/main/java/com/example/sharingang/ItemsListFragment.kt
@@ -10,11 +10,17 @@ import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
 import com.example.sharingang.databinding.FragmentItemsListBinding
 import com.example.sharingang.items.ItemsViewModel
+import com.example.sharingang.users.CurrentUserProvider
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
+@AndroidEntryPoint
 class ItemsListFragment : Fragment() {
 
     private lateinit var binding: FragmentItemsListBinding
     private val viewModel: ItemsViewModel by activityViewModels()
+    @Inject
+    lateinit var currentUserProvider: CurrentUserProvider
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -23,7 +29,7 @@ class ItemsListFragment : Fragment() {
         binding = DataBindingUtil.inflate(inflater, R.layout.fragment_items_list, container, false)
         binding.viewModel = viewModel
 
-        val adapter = viewModel.setupItemAdapter()
+        val adapter = viewModel.setupItemAdapter(currentUserProvider.getCurrentUserId())
         binding.itemList.adapter = adapter
         viewModel.addObserver(viewLifecycleOwner, adapter, ItemsViewModel.OBSERVABLES.ALL_ITEMS)
 

--- a/app/src/main/java/com/example/sharingang/SearchFragment.kt
+++ b/app/src/main/java/com/example/sharingang/SearchFragment.kt
@@ -10,15 +10,21 @@ import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
 import com.example.sharingang.databinding.FragmentSearchBinding
 import com.example.sharingang.items.ItemsViewModel
+import com.example.sharingang.users.CurrentUserProvider
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
+@AndroidEntryPoint
 class SearchFragment : Fragment() {
 
     private val viewModel : ItemsViewModel by activityViewModels()
+    @Inject
+    lateinit var currentUserProvider: CurrentUserProvider
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
                               savedInstanceState: Bundle?): View {
         val binding : FragmentSearchBinding = DataBindingUtil.inflate(inflater, R.layout.fragment_search, container, false)
-        val adapter = viewModel.setupItemAdapter()
+        val adapter = viewModel.setupItemAdapter(currentUserProvider.getCurrentUserId())
         binding.itemSearchList.adapter = adapter
         viewModel.addObserver(viewLifecycleOwner, adapter, ItemsViewModel.OBSERVABLES.SEARCH_RESULTS)
         binding.sflSearchButton.setOnClickListener{

--- a/app/src/main/java/com/example/sharingang/UserProfileFragment.kt
+++ b/app/src/main/java/com/example/sharingang/UserProfileFragment.kt
@@ -47,9 +47,10 @@ class UserProfileFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View {
         binding = UserProfileFragmentBinding.inflate(inflater, container, false)
+        currentUserId = currentUserProvider.getCurrentUserId()
         // If no userId is provided, we get the user that is currently logged in.
         shownUserProfileId = when(args.userId) {
-            null, "" -> currentUserProvider.getCurrentUserId()
+            null, "" -> currentUserId
             else -> args.userId
         }
         userViewModel.setUser(shownUserProfileId)
@@ -59,7 +60,6 @@ class UserProfileFragment : Fragment() {
         userViewModel.user.observe(viewLifecycleOwner, { user ->
             displayUserFields(user)
         })
-
         setupRecyclerView(shownUserProfileId)
         binding.viewModel = userViewModel
         loggedInUserEmail = currentUserProvider.getCurrentUserEmail()
@@ -83,7 +83,6 @@ class UserProfileFragment : Fragment() {
     }
 
     private fun setupButtonsVisibility() {
-        currentUserId = currentUserProvider.getCurrentUserId()
         val pictureButtonsRow = binding.gallerycameraholder
         if(currentUserId != null && isAuthUserDisplayedUser()) {
             pictureButtonsRow.visibility = View.VISIBLE
@@ -91,7 +90,7 @@ class UserProfileFragment : Fragment() {
     }
 
     private fun setupRecyclerView(userId: String?) {
-        val adapter = itemsViewModel.setupItemAdapter()
+        val adapter = itemsViewModel.setupItemAdapter(currentUserId)
         binding.userItemList.adapter = adapter
         itemsViewModel.getUserItem(userId)
         itemsViewModel.addObserver(viewLifecycleOwner, adapter, ItemsViewModel.OBSERVABLES.USER_ITEMS)

--- a/app/src/main/java/com/example/sharingang/WishlistViewFragment.kt
+++ b/app/src/main/java/com/example/sharingang/WishlistViewFragment.kt
@@ -9,26 +9,32 @@ import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
 import com.example.sharingang.databinding.FragmentWishlistViewBinding
 import com.example.sharingang.items.ItemsViewModel
+import com.example.sharingang.users.CurrentUserProvider
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
+@AndroidEntryPoint
 class WishlistViewFragment : Fragment() {
 
     private lateinit var binding: FragmentWishlistViewBinding
     private val viewModel: ItemsViewModel by activityViewModels()
-    private val userviewModel: UserProfileViewModel by activityViewModels()
+    private val userViewModel: UserProfileViewModel by activityViewModels()
+    @Inject
+    lateinit var currentUserProvider: CurrentUserProvider
 
     override fun onResume() {
         super.onResume()
-        userviewModel.refreshListUI(viewModel)
+        userViewModel.refreshListUI(viewModel)
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
                               savedInstanceState: Bundle?
     ): View {
         binding = FragmentWishlistViewBinding.inflate(inflater, container, false)
-        val adapter = viewModel.setupItemAdapter()
+        val adapter = viewModel.setupItemAdapter(currentUserProvider.getCurrentUserId())
         binding.wishlistview.adapter = adapter
         viewModel.addObserver(viewLifecycleOwner, adapter, ItemsViewModel.OBSERVABLES.WISHLIST)
-        userviewModel.refreshListUI(viewModel)
+        userViewModel.refreshListUI(viewModel)
 
         viewModel.setupItemNavigation(viewLifecycleOwner, this.findNavController(),
                 {item -> WishlistViewFragmentDirections.actionWishlistViewFragmentToEditItemFragment(item)},

--- a/app/src/main/java/com/example/sharingang/items/ItemsAdapter.kt
+++ b/app/src/main/java/com/example/sharingang/items/ItemsAdapter.kt
@@ -6,8 +6,11 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.example.sharingang.databinding.ItemViewBinding
+import com.example.sharingang.users.CurrentUserProvider
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
-class ItemsAdapter(private val clickListener: ItemListener) :
+class ItemsAdapter(private val clickListener: ItemListener, private val userId: String?) :
     ListAdapter<Item, ItemsAdapter.ItemViewHolder>(ItemsDiffCallback()) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ItemViewHolder {
@@ -15,16 +18,17 @@ class ItemsAdapter(private val clickListener: ItemListener) :
     }
 
     override fun onBindViewHolder(holder: ItemViewHolder, position: Int) {
-        holder.bind(getItem(position)!!, clickListener)
+        holder.bind(getItem(position)!!, clickListener, userId)
     }
 
     class ItemViewHolder private constructor(private val binding: ItemViewBinding) :
         RecyclerView.ViewHolder(binding.root) {
 
-        fun bind(item: Item, clickListener: ItemListener) {
+        fun bind(item: Item, clickListener: ItemListener, userId: String?) {
             binding.itemListViewTitle.text = item.title
             binding.item = item
             binding.clickListener = clickListener
+            binding.isVisible = item.userId?.equals(userId) ?: false
         }
 
         companion object {

--- a/app/src/main/java/com/example/sharingang/items/ItemsViewModel.kt
+++ b/app/src/main/java/com/example/sharingang/items/ItemsViewModel.kt
@@ -147,11 +147,11 @@ class ItemsViewModel @Inject constructor(
         }
     }
 
-    fun setupItemAdapter(): ItemsAdapter {
+    fun setupItemAdapter(userId: String?): ItemsAdapter {
         val onEdit = { item: Item -> onEditItemClicked(item) }
         val onView = { item: Item -> onViewItem(item) }
         val onSell = { item: Item -> onSellItem(item) }
-        return ItemsAdapter(ItemListener(onEdit, onView, onSell))
+        return ItemsAdapter(ItemListener(onEdit, onView, onSell), userId)
     }
 
     fun addObserver(LifeCycleOwner: LifecycleOwner, adapter: ItemsAdapter, type: OBSERVABLES) {

--- a/app/src/main/res/layout/item_view.xml
+++ b/app/src/main/res/layout/item_view.xml
@@ -4,6 +4,8 @@
 
     <data>
 
+        <import type="android.view.View" />
+
         <variable
             name="item"
             type="com.example.sharingang.items.Item" />
@@ -11,6 +13,10 @@
         <variable
             name="clickListener"
             type="com.example.sharingang.items.ItemListener" />
+
+        <variable
+            name="isVisible"
+            type="boolean" />
     </data>
 
     <LinearLayout
@@ -24,10 +30,10 @@
             android:layout_height="wrap_content"
             android:clickable="true"
             android:focusable="true"
-            android:textColor="@{item.sold ? @android:color/holo_red_dark : @color/black}"
             android:onClick="@{() -> clickListener.onView(item)}"
             android:paddingStart="16dp"
             android:paddingEnd="16dp"
+            android:textColor="@{item.sold ? @android:color/holo_red_dark : @color/black}"
             android:textSize="24sp"
             tools:text="Test" />
 
@@ -37,7 +43,8 @@
             android:layout_height="wrap_content"
             android:onClick="@{() -> clickListener.onEdit(item)}"
             android:text="@string/edit"
-            android:textSize="20sp" />
+            android:textSize="20sp"
+            android:visibility="@{isVisible ? View.VISIBLE : View.GONE}" />
 
         <Button
             android:id="@+id/item_list_view_sell_button"
@@ -46,7 +53,8 @@
             android:layout_weight="0"
             android:onClick="@{() -> clickListener.onSell(item)}"
             android:text="@{item.sold ? @string/unsell : @string/sell}"
-            android:textSize="20sp" />
+            android:textSize="20sp"
+            android:visibility="@{isVisible ? View.VISIBLE : View.GONE}" />
 
     </LinearLayout>
 </layout>


### PR DESCRIPTION
Fixes #142 
Fixes #141 

Now the edit and sell buttons will be hidden from other users that don't own the item.

<img src="https://user-images.githubusercontent.com/56882350/115705174-851d0880-a36c-11eb-9987-ad570df8f43e.png" width=200 />
