### PR TITLE
View images in grid format

### DIFF
--- a/app/src/main/java/com/example/sharingang/ItemsListFragment.kt
+++ b/app/src/main/java/com/example/sharingang/ItemsListFragment.kt
@@ -8,11 +8,14 @@ import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
+import androidx.recyclerview.widget.GridLayoutManager
 import com.example.sharingang.databinding.FragmentItemsListBinding
 import com.example.sharingang.items.ItemsViewModel
 import com.example.sharingang.users.CurrentUserProvider
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
+
+const val COLUMNS = 2
 
 @AndroidEntryPoint
 class ItemsListFragment : Fragment() {
@@ -31,6 +34,7 @@ class ItemsListFragment : Fragment() {
 
         val adapter = viewModel.setupItemAdapter(currentUserProvider.getCurrentUserId())
         binding.itemList.adapter = adapter
+        binding.itemList.layoutManager = GridLayoutManager(context, COLUMNS)
         viewModel.addObserver(viewLifecycleOwner, adapter, ItemsViewModel.OBSERVABLES.ALL_ITEMS)
 
         viewModel.setupItemNavigation(viewLifecycleOwner, this.findNavController(),

--- a/app/src/main/java/com/example/sharingang/ItemsListFragment.kt
+++ b/app/src/main/java/com/example/sharingang/ItemsListFragment.kt
@@ -15,8 +15,6 @@ import com.example.sharingang.users.CurrentUserProvider
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
-const val COLUMNS = 2
-
 @AndroidEntryPoint
 class ItemsListFragment : Fragment() {
 
@@ -34,7 +32,7 @@ class ItemsListFragment : Fragment() {
 
         val adapter = viewModel.setupItemAdapter(currentUserProvider.getCurrentUserId())
         binding.itemList.adapter = adapter
-        binding.itemList.layoutManager = GridLayoutManager(context, COLUMNS)
+        binding.itemList.layoutManager = GridLayoutManager(context, 2)
         viewModel.addObserver(viewLifecycleOwner, adapter, ItemsViewModel.OBSERVABLES.ALL_ITEMS)
 
         viewModel.setupItemNavigation(viewLifecycleOwner, this.findNavController(),

--- a/app/src/main/java/com/example/sharingang/SearchFragment.kt
+++ b/app/src/main/java/com/example/sharingang/SearchFragment.kt
@@ -8,6 +8,7 @@ import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
+import androidx.recyclerview.widget.GridLayoutManager
 import com.example.sharingang.databinding.FragmentSearchBinding
 import com.example.sharingang.items.ItemsViewModel
 import com.example.sharingang.users.CurrentUserProvider
@@ -26,6 +27,7 @@ class SearchFragment : Fragment() {
         val binding : FragmentSearchBinding = DataBindingUtil.inflate(inflater, R.layout.fragment_search, container, false)
         val adapter = viewModel.setupItemAdapter(currentUserProvider.getCurrentUserId())
         binding.itemSearchList.adapter = adapter
+        binding.itemSearchList.layoutManager = GridLayoutManager(context, 2)
         viewModel.addObserver(viewLifecycleOwner, adapter, ItemsViewModel.OBSERVABLES.SEARCH_RESULTS)
         binding.sflSearchButton.setOnClickListener{
             viewModel.searchItems(binding.searchText.text.toString() , binding.searchCategorySpinner.selectedItemPosition)

--- a/app/src/main/java/com/example/sharingang/WishlistViewFragment.kt
+++ b/app/src/main/java/com/example/sharingang/WishlistViewFragment.kt
@@ -1,13 +1,14 @@
 package com.example.sharingang
 
 import android.os.Bundle
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
+import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
+import androidx.recyclerview.widget.GridLayoutManager
 import com.example.sharingang.databinding.FragmentWishlistViewBinding
 import com.example.sharingang.items.ItemsViewModel
 import com.example.sharingang.users.CurrentUserProvider
@@ -20,6 +21,7 @@ class WishlistViewFragment : Fragment() {
     private lateinit var binding: FragmentWishlistViewBinding
     private val viewModel: ItemsViewModel by activityViewModels()
     private val userViewModel: UserProfileViewModel by activityViewModels()
+
     @Inject
     lateinit var currentUserProvider: CurrentUserProvider
 
@@ -29,23 +31,29 @@ class WishlistViewFragment : Fragment() {
         userViewModel.refreshListUI(viewModel)
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
-                              savedInstanceState: Bundle?
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
     ): View {
         binding = FragmentWishlistViewBinding.inflate(inflater, container, false)
         val adapter = viewModel.setupItemAdapter(currentUserProvider.getCurrentUserId())
         binding.wishlistview.adapter = adapter
+        binding.wishlistview.layoutManager = GridLayoutManager(context, 2)
         viewModel.addObserver(viewLifecycleOwner, adapter, ItemsViewModel.OBSERVABLES.WISHLIST)
         userViewModel.refreshListUI(viewModel)
 
         viewModel.setupItemNavigation(viewLifecycleOwner, this.findNavController(),
-                {item -> WishlistViewFragmentDirections.actionWishlistViewFragmentToDetailedItemFragment(item)})
+            { item ->
+                WishlistViewFragmentDirections.actionWishlistViewFragmentToDetailedItemFragment(
+                    item
+                )
+            })
         checkUser()
         return binding.root
     }
 
-    private fun checkUser(){
-        if(currentUserProvider.getCurrentUserId() == null){
+    private fun checkUser() {
+        if (currentUserProvider.getCurrentUserId() == null) {
             Toast.makeText(this.context, "Login to view your wish list", Toast.LENGTH_SHORT).show()
         }
     }

--- a/app/src/main/res/layout/fragment_items_list.xml
+++ b/app/src/main/res/layout/fragment_items_list.xml
@@ -11,10 +11,13 @@
 
     </data>
 
-    <LinearLayout
+    <GridLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:paddingLeft="4dp"
+        android:paddingRight="4dp"
         android:orientation="vertical"
+        android:background="#F3E5F5"
         tools:context=".MainActivity">
 
         <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
@@ -27,8 +30,8 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:scrollbars="vertical"
-                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
+                app:layoutManager="androidx.recyclerview.widget.GridLayoutManager" />
         </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
-    </LinearLayout>
+    </GridLayout>
 </layout>

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -2,11 +2,13 @@
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
+
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context=".SearchFragment"
-        android:orientation="vertical">
+        android:orientation="vertical"
+        tools:context=".SearchFragment">
+
 
         <EditText
             android:id="@+id/searchText"
@@ -19,7 +21,7 @@
             android:id="@+id/searchCategorySpinner"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:entries="@array/categories"/>
+            android:entries="@array/categories" />
 
 
         <LinearLayout
@@ -40,12 +42,22 @@
                 android:text="@string/clear_search_button" />
         </LinearLayout>
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/itemSearchList"
+        <GridLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:scrollbars="vertical"
-            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
+            android:background="#F3E5F5"
+            android:orientation="vertical"
+            android:paddingLeft="4dp"
+            android:paddingRight="4dp"
+            tools:context=".SearchFragment">
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/itemSearchList"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:scrollbars="vertical"
+                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
+        </GridLayout>
 
     </LinearLayout>
 </layout>

--- a/app/src/main/res/layout/fragment_wishlist_view.xml
+++ b/app/src/main/res/layout/fragment_wishlist_view.xml
@@ -1,14 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 
-
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <LinearLayout
+    <GridLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:orientation="vertical">
+        android:background="#F3E5F5"
+        android:orientation="vertical"
+        android:paddingLeft="4dp"
+        android:paddingRight="4dp">
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/wishlistview"
@@ -17,6 +19,6 @@
             android:scrollbars="vertical"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
 
-    </LinearLayout>
+    </GridLayout>
 
 </layout>

--- a/app/src/main/res/layout/item_view.xml
+++ b/app/src/main/res/layout/item_view.xml
@@ -47,6 +47,7 @@
                 android:clickable="true"
                 android:focusable="true"
                 android:gravity="center"
+                android:onClick="@{() -> clickListener.onView(item)}"
                 android:paddingBottom="12dp"
                 android:textColor="@{item.sold ? @android:color/holo_red_dark : @color/black}"
                 android:textSize="24sp"

--- a/app/src/main/res/layout/item_view.xml
+++ b/app/src/main/res/layout/item_view.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
@@ -16,23 +17,43 @@
 
     </data>
 
-    <LinearLayout
+    <androidx.cardview.widget.CardView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal">
+        android:elevation="10dp"
+        android:onClick="@{() -> clickListener.onView(item)}"
+        android:orientation="vertical"
+        app:cardCornerRadius="10dp"
+        app:cardPreventCornerOverlap="true"
+        app:cardUseCompatPadding="true"
+        tools:ignore="UseCompoundDrawables">
 
-        <TextView
-            android:id="@+id/item_list_view_title"
-            android:layout_width="wrap_content"
+        <LinearLayout
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:clickable="true"
-            android:focusable="true"
-            android:onClick="@{() -> clickListener.onView(item)}"
-            android:paddingStart="16dp"
-            android:paddingEnd="16dp"
-            android:textColor="@{item.sold ? @android:color/holo_red_dark : @color/black}"
-            android:textSize="24sp"
-            tools:text="Test" />
+            android:orientation="vertical">
 
-    </LinearLayout>
+            <ImageView
+                android:id="@+id/item_image_preview"
+                android:layout_width="match_parent"
+                android:layout_height="100dp"
+                android:contentDescription="@string/item_image_description"
+                android:src="@drawable/ic_baseline_image_24" />
+
+            <TextView
+                android:id="@+id/item_list_view_title"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:clickable="true"
+                android:focusable="true"
+                android:gravity="center"
+                android:paddingBottom="12dp"
+                android:textColor="@{item.sold ? @android:color/holo_red_dark : @color/black}"
+                android:textSize="24sp"
+                tools:text="Test" />
+
+        </LinearLayout>
+
+
+    </androidx.cardview.widget.CardView>
 </layout>


### PR DESCRIPTION
Fixes #171 
Fixes #155 
![image](https://user-images.githubusercontent.com/22821947/116570590-ad77aa80-a90a-11eb-82b3-1a8d87daeef3.png)
This setups up items to displayed in a nice grid. For now, only placeholder images are used.
Whoever fixes our existing image infrastructure can easily change this code to display the actual image associated with an item, instead of a placeholder. Requesting for permissions is difficult, because when we inflate our view of an item, I don't think we're in any context, so using our permission infra for images is tricky.