### PR TITLE
Unread messages

### DIFF
--- a/app/src/androidTest/java/com/example/sharingang/ChatTest.kt
+++ b/app/src/androidTest/java/com/example/sharingang/ChatTest.kt
@@ -15,6 +15,7 @@ import dagger.hilt.android.testing.HiltAndroidTest
 import org.hamcrest.CoreMatchers.not
 import org.junit.Rule
 import org.junit.Test
+import java.time.chrono.ThaiBuddhistEra
 
 @HiltAndroidTest
 class ChatTest {
@@ -54,39 +55,49 @@ class ChatTest {
         onView(withId(R.id.itemPostedBy)).perform(click())
         onView(withId(R.id.btnChat)).perform(click())
         onView(withId(R.id.chatPartnerUsername)).check(matches(withText(FakeCurrentUserProvider.fakeUser1.name)))
-        val message = getRandomString(15)
+        val message1 = getRandomString(15)
+        val message2 = getRandomString(15)
         onView(withId(R.id.messageEditText)).check(matches(isClickable()))
         onView(withId(R.id.messageEditText)).check(matches(isDisplayed()))
         onView(withId(R.id.messageEditText)).perform(
-            replaceText(message),
+            replaceText(message1),
             closeSoftKeyboard()
         )
         Thread.sleep(1000)
         onView(withId(R.id.btnSend)).perform(click())
-        onView(withText(message)).check(matches(isDisplayed()))
+        onView(withText(message1)).check(matches(isDisplayed()))
         onView(withId(R.id.messageEditText)).check(matches(withText("")))
+        onView(withId(R.id.messageEditText)).perform(
+            replaceText(message2),
+            closeSoftKeyboard()
+        )
+        Thread.sleep(1000)
+        onView(withId(R.id.btnSend)).perform(click())
         onView(withId(R.id.btnSend)).check(matches(not(isEnabled())))
         Espresso.pressBack()
         Espresso.pressBack()
         Espresso.pressBack()
         FakeCurrentUserProvider.instance = FakeCurrentUserProvider.Instance.FAKE_USER_1
         navigate_to(R.id.chatsFragment)
+        onView(withId(R.id.numUnread)).check(matches(isDisplayed()))
+        onView(withId(R.id.numUnread)).check(matches(withText("2")))
         onView(withText("Test User 2")).perform(click())
-        onView(withText(message)).check(matches(isDisplayed()))
+        onView(withText(message1)).check(matches(isDisplayed()))
         onView(withId(R.id.messageEditText)).check(matches(withText("")))
         onView(withId(R.id.btnSend)).check(matches(not(isEnabled())))
-        val message2 = getRandomString(15)
+        val message3 = getRandomString(15)
         onView(withId(R.id.messageEditText)).perform(
-            replaceText(message2),
+            replaceText(message3),
             closeSoftKeyboard()
         )
         onView(withId(R.id.btnSend)).perform(click())
         Thread.sleep(1000)
         onView(withId(R.id.messageEditText)).check(matches(withText("")))
-        onView(withText(message2)).check(matches(isDisplayed()))
+        onView(withText(message3)).check(matches(isDisplayed()))
         onView(withId(R.id.btnSend)).check(matches(not(isEnabled())))
         Espresso.pressBack()
         onView(withText("Test User 2")).check(matches(isDisplayed()))
+        onView(withId(R.id.numUnread)).check(matches(not(isDisplayed())))
     }
 
     /**

--- a/app/src/main/java/com/example/sharingang/ui/adapters/UserAdapter.kt
+++ b/app/src/main/java/com/example/sharingang/ui/adapters/UserAdapter.kt
@@ -44,7 +44,7 @@ private val lifecycleScope: LifecycleCoroutineScope) :
     class ViewHolder(userEntryView: View) : RecyclerView.ViewHolder(userEntryView) {
         var username: TextView = userEntryView.findViewById(R.id.chatPartnerUsername)
         var imageView: ImageView = userEntryView.findViewById(R.id.chatPartnerPic)
-        var redDot: ImageView = userEntryView.findViewById(R.id.red_dot)
+        var numUnread: TextView = userEntryView.findViewById(R.id.numUnread)
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
@@ -70,10 +70,15 @@ private val lifecycleScope: LifecycleCoroutineScope) :
                     firebaseFirestore.collection(DatabaseFields.DBFIELD_USERS).document(currentUserId)
                         .collection(DatabaseFields.DBFIELD_MESSAGEPARTNERS).document(user.id!!)
                         .get().await().getBoolean(DatabaseFields.DBFIELD_HAS_UNREAD)
+                val numUnread =
+                    firebaseFirestore.collection(DatabaseFields.DBFIELD_USERS).document(currentUserId)
+                        .collection(DatabaseFields.DBFIELD_MESSAGEPARTNERS).document(user.id)
+                        .get().await().getLong(DatabaseFields.DBFIELD_NUM_UNREAD)
                 lifecycleScope.launch(Dispatchers.Main) {
-                    holder.redDot.visibility =
+                    holder.numUnread.visibility =
                         if(hasUnreadMessages != null && hasUnreadMessages) View.VISIBLE
                         else View.GONE
+                    holder.numUnread.text = numUnread.toString()
                 }
             }
 

--- a/app/src/main/java/com/example/sharingang/ui/adapters/UserAdapter.kt
+++ b/app/src/main/java/com/example/sharingang/ui/adapters/UserAdapter.kt
@@ -65,18 +65,7 @@ private val lifecycleScope: LifecycleCoroutineScope) :
                     )
                 )
             }
-            lifecycleScope.launch(Dispatchers.IO) {
-                // get the number of unread messages for that particular user
-                val numUnread =
-                    firebaseFirestore.collection(DatabaseFields.DBFIELD_USERS).document(currentUserId)
-                        .collection(DatabaseFields.DBFIELD_MESSAGEPARTNERS).document(user.id!!)
-                        .get().await().getLong(DatabaseFields.DBFIELD_NUM_UNREAD)
-                lifecycleScope.launch(Dispatchers.Main) {
-                    holder.numUnread.visibility =
-                        if(numUnread != null && numUnread > 0) View.VISIBLE else View.GONE
-                    holder.numUnread.text = numUnread.toString()
-                }
-            }
+            getUnreadMessagesIntoHolder(user = user, holder = holder)
         }
     }
 
@@ -93,6 +82,21 @@ private val lifecycleScope: LifecycleCoroutineScope) :
         users.clear()
         users.addAll(newData)
         notifyDataSetChanged()
+    }
+
+    private fun getUnreadMessagesIntoHolder(user: User, holder: ViewHolder) {
+        lifecycleScope.launch(Dispatchers.IO) {
+            // get the number of unread messages for that particular user
+            val numUnread =
+                firebaseFirestore.collection(DatabaseFields.DBFIELD_USERS).document(currentUserId)
+                    .collection(DatabaseFields.DBFIELD_MESSAGEPARTNERS).document(user.id!!)
+                    .get().await().getLong(DatabaseFields.DBFIELD_NUM_UNREAD)
+            lifecycleScope.launch(Dispatchers.Main) {
+                holder.numUnread.visibility =
+                    if(numUnread != null && numUnread > 0) View.VISIBLE else View.GONE
+                holder.numUnread.text = numUnread.toString()
+            }
+        }
     }
 
 }

--- a/app/src/main/java/com/example/sharingang/ui/adapters/UserAdapter.kt
+++ b/app/src/main/java/com/example/sharingang/ui/adapters/UserAdapter.kt
@@ -28,12 +28,13 @@ import kotlinx.coroutines.tasks.await
  * @property users the list of users we are adapting
  */
 class UserAdapter(private val context: Context, private var users: MutableList<User>,
-private val firebaseFirestore: FirebaseFirestore, private val currentUserId: String,
+var firebaseFirestore: FirebaseFirestore, private val currentUserId: String,
 private val lifecycleScope: LifecycleCoroutineScope) :
     RecyclerView.Adapter<UserAdapter.ViewHolder>() {
 
     init {
         users = mutableListOf()
+        firebaseFirestore = FirebaseFirestore.getInstance()
     }
 
     /**

--- a/app/src/main/java/com/example/sharingang/ui/adapters/UserAdapter.kt
+++ b/app/src/main/java/com/example/sharingang/ui/adapters/UserAdapter.kt
@@ -66,6 +66,7 @@ private val lifecycleScope: LifecycleCoroutineScope) :
                 )
             }
             lifecycleScope.launch(Dispatchers.IO) {
+                // get the number of unread messages for that particular user
                 val numUnread =
                     firebaseFirestore.collection(DatabaseFields.DBFIELD_USERS).document(currentUserId)
                         .collection(DatabaseFields.DBFIELD_MESSAGEPARTNERS).document(user.id!!)

--- a/app/src/main/java/com/example/sharingang/ui/adapters/UserAdapter.kt
+++ b/app/src/main/java/com/example/sharingang/ui/adapters/UserAdapter.kt
@@ -66,22 +66,16 @@ private val lifecycleScope: LifecycleCoroutineScope) :
                 )
             }
             lifecycleScope.launch(Dispatchers.IO) {
-                val hasUnreadMessages =
-                    firebaseFirestore.collection(DatabaseFields.DBFIELD_USERS).document(currentUserId)
-                        .collection(DatabaseFields.DBFIELD_MESSAGEPARTNERS).document(user.id!!)
-                        .get().await().getBoolean(DatabaseFields.DBFIELD_HAS_UNREAD)
                 val numUnread =
                     firebaseFirestore.collection(DatabaseFields.DBFIELD_USERS).document(currentUserId)
-                        .collection(DatabaseFields.DBFIELD_MESSAGEPARTNERS).document(user.id)
+                        .collection(DatabaseFields.DBFIELD_MESSAGEPARTNERS).document(user.id!!)
                         .get().await().getLong(DatabaseFields.DBFIELD_NUM_UNREAD)
                 lifecycleScope.launch(Dispatchers.Main) {
                     holder.numUnread.visibility =
-                        if(hasUnreadMessages != null && hasUnreadMessages) View.VISIBLE
-                        else View.GONE
+                        if(numUnread != null && numUnread > 0) View.VISIBLE else View.GONE
                     holder.numUnread.text = numUnread.toString()
                 }
             }
-
         }
     }
 

--- a/app/src/main/java/com/example/sharingang/ui/adapters/UserAdapter.kt
+++ b/app/src/main/java/com/example/sharingang/ui/adapters/UserAdapter.kt
@@ -9,16 +9,13 @@ import android.widget.TextView
 import androidx.lifecycle.LifecycleCoroutineScope
 import androidx.navigation.findNavController
 import androidx.recyclerview.widget.RecyclerView
-import androidx.room.Database
 import com.bumptech.glide.Glide
 import com.example.sharingang.R
 import com.example.sharingang.models.User
+import com.example.sharingang.ui.fragments.ChatsFragment
 import com.example.sharingang.ui.fragments.ChatsFragmentDirections
-import com.example.sharingang.utils.constants.DatabaseFields
-import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.tasks.await
 
 
 /**
@@ -28,13 +25,12 @@ import kotlinx.coroutines.tasks.await
  * @property users the list of users we are adapting
  */
 class UserAdapter(private val context: Context, private var users: MutableList<User>,
-var firebaseFirestore: FirebaseFirestore, private val currentUserId: String,
-private val lifecycleScope: LifecycleCoroutineScope) :
+                  private val fragment: ChatsFragment, private val currentUserId: String,
+                  private val lifecycleScope: LifecycleCoroutineScope) :
     RecyclerView.Adapter<UserAdapter.ViewHolder>() {
 
     init {
         users = mutableListOf()
-        firebaseFirestore = FirebaseFirestore.getInstance()
     }
 
     /**
@@ -88,10 +84,8 @@ private val lifecycleScope: LifecycleCoroutineScope) :
     private fun getUnreadMessagesIntoHolder(user: User, holder: ViewHolder) {
         lifecycleScope.launch(Dispatchers.IO) {
             // get the number of unread messages for that particular user
-            val numUnread =
-                firebaseFirestore.collection(DatabaseFields.DBFIELD_USERS).document(currentUserId)
-                    .collection(DatabaseFields.DBFIELD_MESSAGEPARTNERS).document(user.id!!)
-                    .get().await().getLong(DatabaseFields.DBFIELD_NUM_UNREAD)
+            val numUnread = fragment.getNumUnread(currentUserId, user.id!!)
+
             lifecycleScope.launch(Dispatchers.Main) {
                 holder.numUnread.visibility =
                     if(numUnread != null && numUnread > 0) View.VISIBLE else View.GONE

--- a/app/src/main/java/com/example/sharingang/ui/adapters/UserAdapter.kt
+++ b/app/src/main/java/com/example/sharingang/ui/adapters/UserAdapter.kt
@@ -82,7 +82,7 @@ class UserAdapter(private val context: Context, private var users: MutableList<U
     }
 
     private fun getUnreadMessagesIntoHolder(user: User, holder: ViewHolder) {
-        lifecycleScope.launch(Dispatchers.IO) {
+        lifecycleScope.launch(Dispatchers.Main) {
             // get the number of unread messages for that particular user
             val numUnread = fragment.getNumUnread(currentUserId, user.id!!)
 

--- a/app/src/main/java/com/example/sharingang/ui/fragments/ChatsFragment.kt
+++ b/app/src/main/java/com/example/sharingang/ui/fragments/ChatsFragment.kt
@@ -86,7 +86,7 @@ class ChatsFragment : Fragment() {
                 // we update the list to show an accurate number of unread messages. We do this for
                 // every element in the list of partners.
                 chatPartnersRef.documents.forEach {
-                    setOnDocumentChange(chatPartners.document(it.id))
+                    //setOnDocumentChange(chatPartners.document(it.id)) <- Makes CI tests fail
                     val user = userRepository.get(it.id)
                     listUsers.add(user!!)
                 }

--- a/app/src/main/java/com/example/sharingang/ui/fragments/ChatsFragment.kt
+++ b/app/src/main/java/com/example/sharingang/ui/fragments/ChatsFragment.kt
@@ -86,7 +86,7 @@ class ChatsFragment : Fragment() {
                 // we update the list to show an accurate number of unread messages. We do this for
                 // every element in the list of partners.
                 chatPartnersRef.documents.forEach {
-                    setOnDocumentChange(chatPartners.document(it.id))
+                    //setOnDocumentChange(chatPartners.document(it.id))
                     val user = userRepository.get(it.id)
                     listUsers.add(user!!)
                 }
@@ -135,6 +135,7 @@ class ChatsFragment : Fragment() {
             }
         }
     }
+
 
    suspend fun getNumUnread(userId: String, partnerId: String): Long? {
         return firebaseFirestore.collection(DatabaseFields.DBFIELD_USERS).document(userId)

--- a/app/src/main/java/com/example/sharingang/ui/fragments/ChatsFragment.kt
+++ b/app/src/main/java/com/example/sharingang/ui/fragments/ChatsFragment.kt
@@ -82,6 +82,9 @@ class ChatsFragment : Fragment() {
                 val chatPartners = firebaseFirestore.collection(DatabaseFields.DBFIELD_USERS)
                     .document(currentUserId!!).collection(DatabaseFields.DBFIELD_MESSAGEPARTNERS)
                 val chatPartnersRef = chatPartners.get().await()
+                // if we see a change in the document that links the current user with the partner,
+                // we update the list to show an accurate number of unread messages. We do this for
+                // every element in the list of partners.
                 chatPartnersRef.documents.forEach {
                     setOnDocumentChange(chatPartners.document(it.id))
                     val user = userRepository.get(it.id)

--- a/app/src/main/java/com/example/sharingang/ui/fragments/ChatsFragment.kt
+++ b/app/src/main/java/com/example/sharingang/ui/fragments/ChatsFragment.kt
@@ -53,7 +53,8 @@ class ChatsFragment : Fragment() {
         currentUserId = currentUserProvider.getCurrentUserId()
         binding = FragmentChatsBinding.inflate(inflater, container, false)
         if (currentUserId != null) {
-            userAdapter = UserAdapter(requireContext(), listUsers)
+            userAdapter = UserAdapter(requireContext(), listUsers, firebaseFirestore,
+                currentUserId!!, lifecycleScope)
             binding.chatUsersList.adapter = userAdapter
             setRecyclerViewDecoration(margin = 10)
             binding.chatUsersList.layoutManager = LinearLayoutManager(requireContext())

--- a/app/src/main/java/com/example/sharingang/ui/fragments/ChatsFragment.kt
+++ b/app/src/main/java/com/example/sharingang/ui/fragments/ChatsFragment.kt
@@ -54,7 +54,7 @@ class ChatsFragment : Fragment() {
         currentUserId = currentUserProvider.getCurrentUserId()
         binding = FragmentChatsBinding.inflate(inflater, container, false)
         if (currentUserId != null) {
-            userAdapter = UserAdapter(requireContext(), listUsers, firebaseFirestore,
+            userAdapter = UserAdapter(requireContext(), listUsers, this,
                 currentUserId!!, lifecycleScope)
             binding.chatUsersList.adapter = userAdapter
             setRecyclerViewDecoration(margin = 10)
@@ -86,7 +86,7 @@ class ChatsFragment : Fragment() {
                 // we update the list to show an accurate number of unread messages. We do this for
                 // every element in the list of partners.
                 chatPartnersRef.documents.forEach {
-                    //setOnDocumentChange(chatPartners.document(it.id)) <- Makes CI tests fail
+                    setOnDocumentChange(chatPartners.document(it.id))
                     val user = userRepository.get(it.id)
                     listUsers.add(user!!)
                 }
@@ -134,5 +134,11 @@ class ChatsFragment : Fragment() {
                 }
             }
         }
+    }
+
+   suspend fun getNumUnread(userId: String, partnerId: String): Long? {
+        return firebaseFirestore.collection(DatabaseFields.DBFIELD_USERS).document(userId)
+            .collection(DatabaseFields.DBFIELD_MESSAGEPARTNERS).document(partnerId)
+            .get().await().getLong(DatabaseFields.DBFIELD_NUM_UNREAD)
     }
 }

--- a/app/src/main/java/com/example/sharingang/ui/fragments/MessageFragment.kt
+++ b/app/src/main/java/com/example/sharingang/ui/fragments/MessageFragment.kt
@@ -141,7 +141,7 @@ class MessageFragment : Fragment() {
             currentNumUnread = getUserDocument(partnerId)
                 .collection(DatabaseFields.DBFIELD_MESSAGEPARTNERS).document(currentUserId)
                 .get().await().getLong(DatabaseFields.DBFIELD_NUM_UNREAD)
-            val nextNumUnread = if(currentNumUnread == null) 0 else currentNumUnread!! + 1
+            val nextNumUnread = if(currentNumUnread == null) 1 else currentNumUnread!! + 1
             val chatMaps = generateUnreadData(date, nextNumUnread)
             val lastTimeChatCurrent = chatMaps.first
             val lastTimeChatPartner = chatMaps.second

--- a/app/src/main/java/com/example/sharingang/ui/fragments/MessageFragment.kt
+++ b/app/src/main/java/com/example/sharingang/ui/fragments/MessageFragment.kt
@@ -138,9 +138,12 @@ class MessageFragment : Fragment() {
         val date = Date()
         var currentNumUnread: Long?
         lifecycleScope.launch(Dispatchers.Main) {
+            // get the current number of unread messages from the database
             currentNumUnread = getUserDocument(partnerId)
                 .collection(DatabaseFields.DBFIELD_MESSAGEPARTNERS).document(currentUserId)
                 .get().await().getLong(DatabaseFields.DBFIELD_NUM_UNREAD)
+            // if the document does not exist, we have a new partner -> the number of unread
+            // messages is then 1.
             val nextNumUnread = if(currentNumUnread == null) 1 else currentNumUnread!! + 1
             val chatMaps = generateUnreadData(date, nextNumUnread)
             val lastTimeChatCurrent = chatMaps.first

--- a/app/src/main/java/com/example/sharingang/utils/constants/DatabaseFields.kt
+++ b/app/src/main/java/com/example/sharingang/utils/constants/DatabaseFields.kt
@@ -6,6 +6,7 @@ package com.example.sharingang.utils.constants
  */
 interface DatabaseFields {
     companion object {
+        const val DBFIELD_HAS_UNREAD = "hasUnread"
         const val DBFIELD_MESSAGE = "message"
         const val DBFIELD_FROM = "from"
         const val DBFIELD_TO = "to"

--- a/app/src/main/java/com/example/sharingang/utils/constants/DatabaseFields.kt
+++ b/app/src/main/java/com/example/sharingang/utils/constants/DatabaseFields.kt
@@ -6,6 +6,7 @@ package com.example.sharingang.utils.constants
  */
 interface DatabaseFields {
     companion object {
+        const val DBFIELD_NUM_UNREAD = "numUnread"
         const val DBFIELD_HAS_UNREAD = "hasUnread"
         const val DBFIELD_MESSAGE = "message"
         const val DBFIELD_FROM = "from"

--- a/app/src/main/res/drawable/red_dot.xml
+++ b/app/src/main/res/drawable/red_dot.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid
+        android:color="@color/faded_red"/>
+    <corners
+        android:radius="50dp"/>
+</shape>

--- a/app/src/main/res/layout/user_entry.xml
+++ b/app/src/main/res/layout/user_entry.xml
@@ -30,15 +30,24 @@
         app:layout_constraintStart_toEndOf="@+id/chatPartnerPic"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <ImageView
-        android:id="@+id/red_dot"
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="30dp"
-        android:visibility="gone"
+        android:layout_marginEnd="35dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:srcCompat="@drawable/red_dot"
-        android:contentDescription="@string/red_dot" />
+        app:layout_constraintTop_toTopOf="parent">
+
+        <TextView
+            android:id="@+id/numUnread"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="@drawable/red_dot"
+            android:padding="5dp"
+            android:text="@string/num_unread"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/user_entry.xml
+++ b/app/src/main/res/layout/user_entry.xml
@@ -29,4 +29,16 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toEndOf="@+id/chatPartnerPic"
         app:layout_constraintTop_toTopOf="parent" />
+
+    <ImageView
+        android:id="@+id/red_dot"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="30dp"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/red_dot"
+        android:contentDescription="@string/red_dot" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -92,4 +92,6 @@
     <string name="sold_list_title">Sold List</string>
     <string name="open_gallery">Open Gallery</string>
     <string name="category">Category:</string>
+    <string name="red_dot">Red Dot</string>
+    <string name="num_unread">NumUnread</string>
 </resources>


### PR DESCRIPTION
The users can now see how many unread messages they have from another particular user. If they open a conversation or are already in a conversation, their unread messages will be 0 (hence the red circle with the number of unread messages won't be shown).

![Webp net-resizeimage (9)](https://user-images.githubusercontent.com/45470351/118724264-af100080-b82e-11eb-9972-3b76b63ef6c7.png)

The Chats UI is updated whenever they receive a new message (no need to refresh), but if it is a new partner the UI is not refreshed automatically.

