### PR TITLE
Fix picture buttons color (UserProfile)

### DIFF
--- a/app/src/main/res/layout/user_profile_fragment.xml
+++ b/app/src/main/res/layout/user_profile_fragment.xml
@@ -72,7 +72,7 @@
             android:layout_height="10dp" />
 
         <androidx.constraintlayout.widget.ConstraintLayout
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content">
 
             <ImageView
@@ -90,29 +90,27 @@
                 app:layout_constraintTop_toTopOf="parent"
                 tools:srcCompat="@tools:sample/avatars" />
 
-            <Button
+            <ImageButton
                 android:id="@+id/btn_open_gallery"
-                android:layout_width="64dp"
-                android:layout_height="64dp"
-                android:background="@android:drawable/ic_menu_gallery"
-                android:backgroundTint="#FFFFFFFF"
+                android:layout_width="32dp"
+                android:layout_height="32dp"
+                android:layout_marginEnd="5dp"
+                android:layout_marginBottom="5dp"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="0.512"
-                app:layout_constraintStart_toEndOf="@+id/imageView"
-                app:layout_constraintTop_toTopOf="parent" />
+                app:srcCompat="@android:drawable/ic_menu_gallery"
+                android:contentDescription="@string/open_gallery" />
 
-            <Button
+            <ImageButton
                 android:id="@+id/btn_open_camera"
-                android:layout_width="64dp"
-                android:layout_height="64dp"
-                android:background="@android:drawable/ic_menu_camera"
-                android:backgroundTint="#FFFFFFFF"
+                android:layout_width="32dp"
+                android:layout_height="32dp"
+                android:layout_marginStart="5dp"
+                android:layout_marginBottom="5dp"
                 app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toStartOf="@+id/imageView"
-                app:layout_constraintHorizontal_bias="0.532"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+                app:srcCompat="@android:drawable/ic_menu_camera"
+                android:contentDescription="@string/open_camera"/>
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/user_profile_fragment.xml
+++ b/app/src/main/res/layout/user_profile_fragment.xml
@@ -72,7 +72,7 @@
             android:layout_height="10dp" />
 
         <androidx.constraintlayout.widget.ConstraintLayout
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content">
 
             <ImageView
@@ -91,26 +91,28 @@
                 tools:srcCompat="@tools:sample/avatars" />
 
             <Button
-                android:id="@+id/btn_open_camera"
-                android:layout_width="32dp"
-                android:layout_height="32dp"
-                android:layout_marginStart="5dp"
-                android:layout_marginBottom="5dp"
-                android:background="@android:drawable/ic_menu_camera"
-                android:backgroundTint="#FFFFFFFF"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toStartOf="parent" />
-
-            <Button
                 android:id="@+id/btn_open_gallery"
-                android:layout_width="32dp"
-                android:layout_height="32dp"
-                android:layout_marginEnd="5dp"
-                android:layout_marginBottom="5dp"
+                android:layout_width="64dp"
+                android:layout_height="64dp"
                 android:background="@android:drawable/ic_menu_gallery"
                 android:backgroundTint="#FFFFFFFF"
                 app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent" />
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.512"
+                app:layout_constraintStart_toEndOf="@+id/imageView"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <Button
+                android:id="@+id/btn_open_camera"
+                android:layout_width="64dp"
+                android:layout_height="64dp"
+                android:background="@android:drawable/ic_menu_camera"
+                android:backgroundTint="#FFFFFFFF"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toStartOf="@+id/imageView"
+                app:layout_constraintHorizontal_bias="0.532"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -94,4 +94,5 @@
     <string name="open_gallery">Open Gallery</string>
     <string name="category">Category:</string>
     <string name="required_field">Required field</string>
+    <string name="open_camera">Open Camera</string>
 </resources>


### PR DESCRIPTION
(Too lazy to rescale image)

The buttons were sometimes blending with the picture due to their bright/dark; now the color is fixed and won't blend anymore.

![Screenshot from 2021-05-19 22-24-09](https://user-images.githubusercontent.com/45470351/118881099-f790f200-b8f2-11eb-9a31-72df82fc6dc0.png)
