### PR TITLE
Discounts

### DIFF
--- a/app/src/androidTest/java/com/example/sharingang/EditItemFragmentTest.kt
+++ b/app/src/androidTest/java/com/example/sharingang/EditItemFragmentTest.kt
@@ -140,4 +140,48 @@ class EditItemFragmentTest {
         onView(withId(R.id.item_image)).check(matches(hasContentDescription()))
         Intents.release()
     }
+
+    @Test
+    fun anItemCanBeDiscounted() {
+        val price = "5"
+        val discountPrice = "2"
+        val badDiscountPrice = "6"
+        navigate_to(R.id.newEditFragment)
+        onView(withId(R.id.itemTitle)).perform(
+            typeText(item),
+            closeSoftKeyboard()
+        )
+
+        onView(withId(R.id.itemPrice)).perform(
+            replaceText(price),
+            closeSoftKeyboard()
+        )
+
+        onView(withId(R.id.saveItemButton)).perform(scrollTo(), click())
+        waitAfterSaveItem()
+
+        onView(withText(item)).check(matches(isDisplayed()))
+        onView(withId(R.id.item_list_view_title)).perform(click())
+
+        onView(withMenuIdOrText(R.id.menuEdit, R.string.edit_item)).perform(click())
+
+        onView(withId(R.id.switch_is_discount)).perform(click())
+        onView(withId(R.id.discountPrice)).perform(
+            replaceText(badDiscountPrice),
+            closeSoftKeyboard()
+        )
+
+        onView(withId(R.id.saveItemButton)).perform(scrollTo(), click())
+        Thread.sleep(500)
+
+        onView(withId(R.id.discountPrice)).perform(
+            replaceText(discountPrice),
+            closeSoftKeyboard()
+        )
+
+        onView(withId(R.id.saveItemButton)).perform(scrollTo(), click())
+        waitAfterSaveItem()
+
+        onView(withId(R.id.itemDiscountPrice)).check(matches(isDisplayed()))
+    }
 }

--- a/app/src/main/java/com/example/sharingang/models/Item.kt
+++ b/app/src/main/java/com/example/sharingang/models/Item.kt
@@ -31,6 +31,9 @@ data class Item(
 
     val price: Double = 0.0,
 
+    val discount: Boolean = false,
+    val discountPrice: Double = 0.0,
+
     val sold: Boolean = false,
 
     var category: Int = 0,

--- a/app/src/main/java/com/example/sharingang/ui/fragments/DetailedItemFragment.kt
+++ b/app/src/main/java/com/example/sharingang/ui/fragments/DetailedItemFragment.kt
@@ -31,6 +31,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import android.graphics.Paint
 
 @AndroidEntryPoint
 class DetailedItemFragment : Fragment() {
@@ -79,7 +80,7 @@ class DetailedItemFragment : Fragment() {
         initWishlistButton()
         initRating(args.item)
         initBuy()
-
+        if (args.item.discount) binding.itemPrice.paintFlags = binding.itemPrice.paintFlags or Paint.STRIKE_THRU_TEXT_FLAG
         binding.shareButton.setOnClickListener { shareItem() }
 
         viewModel.setUser(args.item.userId)

--- a/app/src/main/java/com/example/sharingang/ui/fragments/NewEditFragment.kt
+++ b/app/src/main/java/com/example/sharingang/ui/fragments/NewEditFragment.kt
@@ -186,8 +186,15 @@ class NewEditFragment : Fragment() {
             binding.itemTitle.requestFocus()
             getString(R.string.required_field)
         } else null
+        val discountLowerPrice = if (binding.switchIsDiscount.isChecked){
+            binding.priceDiscount?.toDouble() ?: 0.0 < binding.price?.toDouble() ?: 0.0
+        } else true
+        binding.itemDiscountContainer.error = if (!discountLowerPrice) {
+            binding.discountPrice.requestFocus()
+            getString(R.string.discount_lower)
+        } else null
 
-        return !titleEmpty
+        return !titleEmpty && discountLowerPrice
     }
 
     private fun itemToAdd(): Item {

--- a/app/src/main/java/com/example/sharingang/ui/fragments/NewEditFragment.kt
+++ b/app/src/main/java/com/example/sharingang/ui/fragments/NewEditFragment.kt
@@ -205,7 +205,9 @@ class NewEditFragment : Fragment() {
             userId = existingItem?.userId ?: userId!!, // The form is only displayed for logged in users
             createdAt = existingItem?.createdAt,
             localId = existingItem?.localId ?: 0,
-            request = binding.switchIsRequest.isChecked
+            request = binding.switchIsRequest.isChecked,
+            discount = binding.switchIsDiscount.isChecked,
+            discountPrice = binding.priceDiscount?.toDoubleOrNull() ?: 0.0
         )
     }
 
@@ -257,9 +259,19 @@ class NewEditFragment : Fragment() {
                 Glide.with(requireContext()).load(url).into(binding.itemImage)
             }
             binding.switchIsRequest.isChecked = it.request
+            binding.switchIsDiscount.isChecked = it.discount
+            binding.isDiscount = it.discount
+            setupDiscountSwitch()
+            binding.priceDiscount = it.discountPrice.toString().format("%.2f")
             updateLocationWithCoordinates(it.latitude, it.longitude)
         }
 
         binding.itemTitle.doOnTextChanged { _, _, _, _ -> validateForm() }
+    }
+
+    private fun setupDiscountSwitch() {
+        binding.switchIsDiscount.setOnCheckedChangeListener{_, isChecked ->
+            binding.isDiscount = isChecked
+        }
     }
 }

--- a/app/src/main/java/com/example/sharingang/ui/fragments/NewEditFragment.kt
+++ b/app/src/main/java/com/example/sharingang/ui/fragments/NewEditFragment.kt
@@ -272,8 +272,6 @@ class NewEditFragment : Fragment() {
             binding.priceDiscount = it.discountPrice.toString().format("%.2f")
             updateLocationWithCoordinates(it.latitude, it.longitude)
         }
-
-        binding.itemTitle.doOnTextChanged { _, _, _, _ -> validateForm() }
     }
 
     private fun setupDiscountSwitch() {

--- a/app/src/main/res/layout/fragment_detailed_item.xml
+++ b/app/src/main/res/layout/fragment_detailed_item.xml
@@ -58,13 +58,29 @@
             android:textSize="25sp"
             tools:text="Category" />
 
-        <TextView
-            android:id="@+id/itemPrice"
+        <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@{@string/display_price(item.price)}"
-            android:textSize="18sp"
-            tools:text="10.00" />
+            android:layout_height="wrap_content">
+
+            <TextView
+                android:id="@+id/itemPrice"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@{@string/display_price(item.price)}"
+                android:textSize="18sp"
+                tools:text="10.00" />
+
+            <TextView
+                android:id="@+id/itemDiscountPrice"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="12dp"
+                android:text="@{@string/display_price(item.discountPrice)}"
+                android:visibility="@{item.discount ? View.VISIBLE : View.GONE}"
+                android:textSize="18sp"
+                tools:text="10.00" />
+
+        </LinearLayout>
 
         <TextView
             android:id="@+id/itemDescription"

--- a/app/src/main/res/layout/fragment_new_edit_item.xml
+++ b/app/src/main/res/layout/fragment_new_edit_item.xml
@@ -38,6 +38,14 @@
         <variable
             name="isLoading"
             type="Boolean" />
+
+        <variable
+            name="isDiscount"
+            type="Boolean" />
+
+        <variable
+            name="priceDiscount"
+            type="String" />
     </data>
 
     <LinearLayout
@@ -60,7 +68,7 @@
             android:textAlignment="center"
             android:textSize="18sp"
             android:visibility="@{isAuthenticated ? View.GONE : View.VISIBLE}"
-            tools:visibility="gone"/>
+            tools:visibility="gone" />
 
         <ScrollView
             android:layout_width="match_parent"
@@ -212,6 +220,42 @@
                         android:text="@={price}" />
 
                 </com.google.android.material.textfield.TextInputLayout>
+
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="10dp" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:gravity="start">
+
+                    <androidx.appcompat.widget.SwitchCompat
+                        android:id="@+id/switch_is_discount"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/is_discount"
+                        android:textSize="17sp"
+                        android:visibility="@{isNewItem ? View.GONE : View.VISIBLE}" />
+
+                    <com.google.android.material.textfield.TextInputLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:hint="@string/price"
+                        android:visibility="@{isDiscount ? View.VISIBLE : View.GONE}"
+                        app:suffixText="CHF">
+
+                        <com.google.android.material.textfield.TextInputEditText
+                            android:id="@+id/discountPrice"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:inputType="numberDecimal"
+                            android:text="@={priceDiscount}" />
+
+                    </com.google.android.material.textfield.TextInputLayout>
+
+                </LinearLayout>
 
                 <Space
                     android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_new_edit_item.xml
+++ b/app/src/main/res/layout/fragment_new_edit_item.xml
@@ -240,6 +240,7 @@
                         android:visibility="@{isNewItem ? View.GONE : View.VISIBLE}" />
 
                     <com.google.android.material.textfield.TextInputLayout
+                        android:id="@+id/itemDiscountContainer"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:hint="@string/price"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -95,4 +95,5 @@
     <string name="category">Category:</string>
     <string name="required_field">Required field</string>
     <string name="is_discount">Discount?</string>
+    <string name="discount_lower">Discount price must be lower</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -94,4 +94,5 @@
     <string name="open_gallery">Open Gallery</string>
     <string name="category">Category:</string>
     <string name="required_field">Required field</string>
+    <string name="is_discount">Discount?</string>
 </resources>

--- a/functions/index.js
+++ b/functions/index.js
@@ -110,7 +110,12 @@ async function getOrCreateCustomer(user) {
  */
 async function createPaymentIntent(customer, user, item, itemId) {
     // Stripe expects price in cents
-    const price = Math.round(item.price * 100);
+    var price = 0;
+    if (item.discount) {
+        price = Math.round(item.discountPrice * 100);
+    } else {
+        price = Math.round(item.price * 100);
+    }
 
     const paymentIntent = await stripe.paymentIntents.create({
         amount: price,


### PR DESCRIPTION
Fixes #240 
Fixes #257

Users can now set an item as being discounted, so other users might be more interested in it. The discount price field is only shown when the discount switch is checked. There is also a validation that happens to check that the discount price is lower than the normal price.
Also on the detailed view of an item, we see the old price crossed and the new price next to it.

<img src="https://user-images.githubusercontent.com/56882350/118970007-0a94d800-b96e-11eb-9da8-fa1573f43449.png" width=200 />
<img src="https://user-images.githubusercontent.com/56882350/118970014-0d8fc880-b96e-11eb-99e9-a46a2a4fa6fd.png" width=200 />
