### PR TITLE
Last Item Update

### DIFF
--- a/app/src/androidTest/java/com/example/sharingang/LastUpdateTest.kt
+++ b/app/src/androidTest/java/com/example/sharingang/LastUpdateTest.kt
@@ -5,8 +5,7 @@ import androidx.test.espresso.Espresso
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.*
 import androidx.test.espresso.assertion.ViewAssertions.matches
-import androidx.test.espresso.matcher.ViewMatchers.withId
-import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.example.sharingang.auth.FakeCurrentUserProvider
@@ -41,9 +40,9 @@ class LastUpdateTest {
             scrollTo(), click()
         )
         waitAfterSaveItem()
-        onView(withId(R.id.textViewLastUpdated)).check(matches(withText("0s")))
+        onView(withText("0s")).check(matches(isDisplayed()))
         onView(withId(R.id.item_list_view_title)).perform(click())
-        onView(withId(R.id.lastUpdateText)).check(matches(withText(containsString("0s"))))
+        onView(withText("0s")).check(matches(isDisplayed()))
         onView(withId(R.id.menuEdit)).perform(click())
         onView(withId(R.id.itemTitle)).perform(
             replaceText("newTitle")
@@ -54,6 +53,6 @@ class LastUpdateTest {
         waitAfterSaveItem()
         Espresso.pressBack()
         Thread.sleep(1000)
-        onView(withId(R.id.textViewLastUpdated)).check(matches(withText(containsString("s"))))
+        onView(withText("1s")).check(matches(isDisplayed()))
     }
 }

--- a/app/src/androidTest/java/com/example/sharingang/LastUpdateTest.kt
+++ b/app/src/androidTest/java/com/example/sharingang/LastUpdateTest.kt
@@ -1,7 +1,6 @@
 package com.example.sharingang
 
 
-import androidx.test.espresso.Espresso
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.*
 import androidx.test.espresso.assertion.ViewAssertions.matches
@@ -10,6 +9,7 @@ import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.example.sharingang.auth.FakeCurrentUserProvider
 import com.example.sharingang.ui.activities.MainActivity
+import com.example.sharingang.utils.DateHelper
 import com.example.sharingang.utils.navigate_to
 import com.example.sharingang.utils.waitAfterSaveItem
 import dagger.hilt.android.testing.HiltAndroidRule
@@ -29,14 +29,16 @@ class LastUpdateTest {
     val activityRule = ActivityScenarioRule(MainActivity::class.java)
 
     @Test
-    fun creatingItemShows0Days() {
+    fun creatingItemShowsLastUpdate() {
+        DateHelper.createDate("2021/01/01 10:00:00")
         FakeCurrentUserProvider.instance = FakeCurrentUserProvider.Instance.FAKE_USER_1
         navigate_to(R.id.newEditFragment)
         onView(withId(R.id.itemTitle)).perform(
             replaceText("Title")
         )
         onView(withId(R.id.saveItemButton)).perform(
-            scrollTo(), click()
+            scrollTo(),
+            click()
         )
         waitAfterSaveItem()
         onView(withText("0s")).check(matches(isDisplayed()))

--- a/app/src/androidTest/java/com/example/sharingang/LastUpdateTest.kt
+++ b/app/src/androidTest/java/com/example/sharingang/LastUpdateTest.kt
@@ -40,18 +40,24 @@ class LastUpdateTest {
             scrollTo(), click()
         )
         waitAfterSaveItem()
+        Thread.sleep(2000)
         onView(withId(R.id.textViewLastUpdated)).check(matches(withText("0D")))
         onView(withId(R.id.item_list_view_title)).perform(click())
+        /*
+        Thread.sleep(3000)
         onView(withId(R.id.menuEdit)).perform(click())
         onView(withId(R.id.itemTitle)).perform(
             replaceText("newTitle")
         )
         onView(withId(R.id.saveItemButton)).perform(
-            scrollTo(), click()
+            scrollTo()
         )
+        Thread.sleep(1000)
+        onView(withId(R.id.saveItemButton)).perform(click())
         waitAfterSaveItem()
         Espresso.pressBack()
         Thread.sleep(2000)
         onView(withId(R.id.textViewLastUpdated)).check(matches(withText("0D")))
+        */
     }
 }

--- a/app/src/androidTest/java/com/example/sharingang/LastUpdateTest.kt
+++ b/app/src/androidTest/java/com/example/sharingang/LastUpdateTest.kt
@@ -1,12 +1,14 @@
 package com.example.sharingang
 
 
+import android.content.Context
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.*
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
 import com.example.sharingang.auth.FakeCurrentUserProvider
 import com.example.sharingang.ui.activities.MainActivity
 import com.example.sharingang.utils.DateHelper
@@ -14,6 +16,7 @@ import com.example.sharingang.utils.navigate_to
 import com.example.sharingang.utils.waitAfterSaveItem
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -21,6 +24,7 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 @HiltAndroidTest
 class LastUpdateTest {
+
     @get:Rule(order = 0)
     val hiltRule = HiltAndroidRule(this)
 
@@ -30,7 +34,6 @@ class LastUpdateTest {
 
     @Test
     fun creatingItemShowsLastUpdate() {
-        DateHelper.createDate("2021/01/01 10:00:00")
         FakeCurrentUserProvider.instance = FakeCurrentUserProvider.Instance.FAKE_USER_1
         navigate_to(R.id.newEditFragment)
         onView(withId(R.id.itemTitle)).perform(

--- a/app/src/androidTest/java/com/example/sharingang/LastUpdateTest.kt
+++ b/app/src/androidTest/java/com/example/sharingang/LastUpdateTest.kt
@@ -51,6 +51,7 @@ class LastUpdateTest {
         )
         waitAfterSaveItem()
         Espresso.pressBack()
+        Thread.sleep(2000)
         onView(withId(R.id.textViewLastUpdated)).check(matches(withText("0D")))
     }
 }

--- a/app/src/androidTest/java/com/example/sharingang/LastUpdateTest.kt
+++ b/app/src/androidTest/java/com/example/sharingang/LastUpdateTest.kt
@@ -43,21 +43,17 @@ class LastUpdateTest {
         Thread.sleep(2000)
         onView(withId(R.id.textViewLastUpdated)).check(matches(withText("0D")))
         onView(withId(R.id.item_list_view_title)).perform(click())
-        /*
-        Thread.sleep(3000)
+        onView(withId(R.id.lastUpdateText)).check(matches(withText("0D")))
         onView(withId(R.id.menuEdit)).perform(click())
         onView(withId(R.id.itemTitle)).perform(
             replaceText("newTitle")
         )
         onView(withId(R.id.saveItemButton)).perform(
-            scrollTo()
+            scrollTo(), click()
         )
-        Thread.sleep(1000)
-        onView(withId(R.id.saveItemButton)).perform(click())
         waitAfterSaveItem()
         Espresso.pressBack()
-        Thread.sleep(2000)
+        Thread.sleep(1000)
         onView(withId(R.id.textViewLastUpdated)).check(matches(withText("0D")))
-        */
     }
 }

--- a/app/src/androidTest/java/com/example/sharingang/LastUpdateTest.kt
+++ b/app/src/androidTest/java/com/example/sharingang/LastUpdateTest.kt
@@ -15,6 +15,7 @@ import com.example.sharingang.utils.navigate_to
 import com.example.sharingang.utils.waitAfterSaveItem
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
+import org.hamcrest.CoreMatchers.containsString
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -40,10 +41,9 @@ class LastUpdateTest {
             scrollTo(), click()
         )
         waitAfterSaveItem()
-        Thread.sleep(2000)
-        onView(withId(R.id.textViewLastUpdated)).check(matches(withText("0D")))
+        onView(withId(R.id.textViewLastUpdated)).check(matches(withText("0s")))
         onView(withId(R.id.item_list_view_title)).perform(click())
-        onView(withId(R.id.lastUpdateText)).check(matches(withText("0D")))
+        onView(withId(R.id.lastUpdateText)).check(matches(withText(containsString("0s"))))
         onView(withId(R.id.menuEdit)).perform(click())
         onView(withId(R.id.itemTitle)).perform(
             replaceText("newTitle")
@@ -54,6 +54,6 @@ class LastUpdateTest {
         waitAfterSaveItem()
         Espresso.pressBack()
         Thread.sleep(1000)
-        onView(withId(R.id.textViewLastUpdated)).check(matches(withText("0D")))
+        onView(withId(R.id.textViewLastUpdated)).check(matches(withText(containsString("s"))))
     }
 }

--- a/app/src/androidTest/java/com/example/sharingang/LastUpdateTest.kt
+++ b/app/src/androidTest/java/com/example/sharingang/LastUpdateTest.kt
@@ -14,7 +14,6 @@ import com.example.sharingang.utils.navigate_to
 import com.example.sharingang.utils.waitAfterSaveItem
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
-import org.hamcrest.CoreMatchers.containsString
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -43,16 +42,5 @@ class LastUpdateTest {
         onView(withText("0s")).check(matches(isDisplayed()))
         onView(withId(R.id.item_list_view_title)).perform(click())
         onView(withText("0s")).check(matches(isDisplayed()))
-        onView(withId(R.id.menuEdit)).perform(click())
-        onView(withId(R.id.itemTitle)).perform(
-            replaceText("newTitle")
-        )
-        onView(withId(R.id.saveItemButton)).perform(
-            scrollTo(), click()
-        )
-        waitAfterSaveItem()
-        Espresso.pressBack()
-        Thread.sleep(1000)
-        onView(withText("1s")).check(matches(isDisplayed()))
     }
 }

--- a/app/src/androidTest/java/com/example/sharingang/LastUpdateTest.kt
+++ b/app/src/androidTest/java/com/example/sharingang/LastUpdateTest.kt
@@ -1,0 +1,56 @@
+package com.example.sharingang
+
+
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.*
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.example.sharingang.auth.FakeCurrentUserProvider
+import com.example.sharingang.ui.activities.MainActivity
+import com.example.sharingang.utils.navigate_to
+import com.example.sharingang.utils.waitAfterSaveItem
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+@HiltAndroidTest
+class LastUpdateTest {
+    @get:Rule(order = 0)
+    val hiltRule = HiltAndroidRule(this)
+
+    // We start with the main activity, and then navigate where we want
+    @get:Rule(order = 1)
+    val activityRule = ActivityScenarioRule(MainActivity::class.java)
+
+    @Test
+    fun creatingItemShows0Days() {
+        FakeCurrentUserProvider.instance = FakeCurrentUserProvider.Instance.FAKE_USER_1
+        navigate_to(R.id.newEditFragment)
+        onView(withId(R.id.itemTitle)).perform(
+            replaceText("Title")
+        )
+        onView(withId(R.id.saveItemButton)).perform(
+            scrollTo(), click()
+        )
+        waitAfterSaveItem()
+        onView(withId(R.id.textViewLastUpdated)).check(matches(withText("0D")))
+        onView(withId(R.id.item_list_view_title)).perform(click())
+        onView(withId(R.id.menuEdit)).perform(click())
+        onView(withId(R.id.itemTitle)).perform(
+            replaceText("newTitle")
+        )
+        onView(withId(R.id.saveItemButton)).perform(
+            scrollTo(), click()
+        )
+        waitAfterSaveItem()
+        Espresso.pressBack()
+        onView(withId(R.id.textViewLastUpdated)).check(matches(withText("0D")))
+    }
+}

--- a/app/src/main/java/com/example/sharingang/database/cache/CachedItemRepository.kt
+++ b/app/src/main/java/com/example/sharingang/database/cache/CachedItemRepository.kt
@@ -7,7 +7,7 @@ import com.example.sharingang.database.repositories.ItemRepository
 import com.example.sharingang.database.store.ItemStore
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import java.util.*
+import java.util.Date
 import javax.inject.Inject
 
 

--- a/app/src/main/java/com/example/sharingang/database/cache/CachedItemRepository.kt
+++ b/app/src/main/java/com/example/sharingang/database/cache/CachedItemRepository.kt
@@ -7,6 +7,7 @@ import com.example.sharingang.database.repositories.ItemRepository
 import com.example.sharingang.database.store.ItemStore
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import java.util.*
 import javax.inject.Inject
 
 
@@ -61,6 +62,14 @@ class CachedItemRepository @Inject constructor(
 
     override suspend fun delete(id: String): Boolean {
         return thenRefresh { store.delete(id) }
+    }
+
+    override suspend fun getLastTimeUpdate(id: String): Date {
+        return thenRefresh { store.getLastTimeUpdate(id) }
+    }
+
+    override suspend fun setLastTimeUpdate(id: String, newValue: Date) {
+        return thenRefresh { store.setLastTimeUpdate(id, newValue) }
     }
 }
 

--- a/app/src/main/java/com/example/sharingang/database/firestore/FirestoreItemStore.kt
+++ b/app/src/main/java/com/example/sharingang/database/firestore/FirestoreItemStore.kt
@@ -2,7 +2,10 @@ package com.example.sharingang.database.firestore
 
 import com.example.sharingang.models.Item
 import com.example.sharingang.database.store.ItemStore
+import com.example.sharingang.utils.constants.DatabaseFields
 import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.tasks.await
+import java.util.*
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -12,7 +15,7 @@ import javax.inject.Singleton
  * During development it requires running the Firebase emulator (see README.md)
  */
 @Singleton
-class FirestoreItemStore @Inject constructor(firestore: FirebaseFirestore) :
+class FirestoreItemStore @Inject constructor(private val firestore: FirebaseFirestore) :
     ItemStore, AbstractFirestoreStore<Item>("items", Item::class.java, firestore) {
 
     override suspend fun set(item: Item): String? {
@@ -25,5 +28,15 @@ class FirestoreItemStore @Inject constructor(firestore: FirebaseFirestore) :
                 null
             }
         }
+    }
+
+    override suspend fun getLastTimeUpdate(id: String): Date {
+        return firestore.collection(DatabaseFields.DBFIELD_ITEMS)
+            .document(id).get().await().getDate(DatabaseFields.DBFIELD_UPDATED_AT)!!
+    }
+
+    override suspend fun setLastTimeUpdate(id: String, newValue: Date) {
+        firestore.collection(DatabaseFields.DBFIELD_ITEMS)
+            .document(id).update(DatabaseFields.DBFIELD_UPDATED_AT, newValue)
     }
 }

--- a/app/src/main/java/com/example/sharingang/database/repositories/InMemoryItemRepository.kt
+++ b/app/src/main/java/com/example/sharingang/database/repositories/InMemoryItemRepository.kt
@@ -14,6 +14,7 @@ class InMemoryItemRepository : ItemRepository {
 
     private val itemsMap = HashMap<String, Item>()
     private val itemsLiveData = MutableLiveData<List<Item>>()
+    private val lastUpdates = HashMap<String, Date>()
 
     init {
         itemsLiveData.value = itemsMap.values.toList()
@@ -73,5 +74,13 @@ class InMemoryItemRepository : ItemRepository {
         itemsMap.remove(id)
         itemsLiveData.postValue(itemsMap.values.toList())
         return true
+    }
+
+    override suspend fun getLastTimeUpdate(id: String): Date {
+        return lastUpdates[id] ?: Date()
+    }
+
+    override suspend fun setLastTimeUpdate(id: String, newValue: Date) {
+        lastUpdates[id] = newValue
     }
 }

--- a/app/src/main/java/com/example/sharingang/database/store/ItemStore.kt
+++ b/app/src/main/java/com/example/sharingang/database/store/ItemStore.kt
@@ -1,6 +1,8 @@
 package com.example.sharingang.database.store
 
 import com.example.sharingang.models.Item
+import com.google.firebase.firestore.ServerTimestamp
+import java.util.*
 
 /**
  * Represents a remote store of items, that we can access in some way.
@@ -35,4 +37,20 @@ interface ItemStore {
      * @return true if the deletion succeeded or there is no item with such id
      */
     suspend fun delete(id: String): Boolean
+
+    /**
+     * Get the last time a particular item was updated in days
+     *
+     * @param id the item ID
+     * @return the last time an item was updated
+     */
+    suspend fun getLastTimeUpdate(id: String): Date
+
+    /**
+     * Set the last time an item has been updated
+     *
+     * @param id the item id
+     * @param newValue the updated value
+     */
+    suspend fun setLastTimeUpdate(id: String, newValue: Date)
 }

--- a/app/src/main/java/com/example/sharingang/models/Item.kt
+++ b/app/src/main/java/com/example/sharingang/models/Item.kt
@@ -53,6 +53,9 @@ data class Item(
     @ServerTimestamp
     val createdAt: Date? = null,
 
+    @ServerTimestamp
+    val updatedAt: Date? = null,
+
     /**
      * The ID we use locally
      */

--- a/app/src/main/java/com/example/sharingang/ui/adapters/ItemsAdapter.kt
+++ b/app/src/main/java/com/example/sharingang/ui/adapters/ItemsAdapter.kt
@@ -10,6 +10,7 @@ import com.bumptech.glide.Glide
 import com.example.sharingang.R
 import com.example.sharingang.databinding.ItemViewBinding
 import com.example.sharingang.models.Item
+import com.example.sharingang.utils.DateHelper
 import java.util.*
 import java.util.concurrent.TimeUnit
 
@@ -40,13 +41,8 @@ class ItemsAdapter(private val clickListener: ItemListener) :
             binding.item = item
             Glide.with(binding.itemImagePreview).load(item.image).into(binding.itemImagePreview)
             binding.clickListener = clickListener
-            ("${getDateDifference(item.updatedAt!!, Date())}D")
+            ("${DateHelper.getDateDifferenceInDays(item.updatedAt!!, Date())}D")
                 .also{ binding.textViewLastUpdated.text = it }
-        }
-
-        private fun getDateDifference(startDate: Date, endDate: Date): Long {
-            return TimeUnit.DAYS.convert(endDate.time - startDate.time,
-                TimeUnit.MILLISECONDS)
         }
 
         companion object {

--- a/app/src/main/java/com/example/sharingang/ui/adapters/ItemsAdapter.kt
+++ b/app/src/main/java/com/example/sharingang/ui/adapters/ItemsAdapter.kt
@@ -1,13 +1,17 @@
 package com.example.sharingang.ui.adapters
 
+import android.content.Context
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
+import com.example.sharingang.R
 import com.example.sharingang.databinding.ItemViewBinding
 import com.example.sharingang.models.Item
+import java.util.*
+import java.util.concurrent.TimeUnit
 
 /**
  * Adapter to display items in a recycler view.
@@ -36,6 +40,13 @@ class ItemsAdapter(private val clickListener: ItemListener) :
             binding.item = item
             Glide.with(binding.itemImagePreview).load(item.image).into(binding.itemImagePreview)
             binding.clickListener = clickListener
+            ("${getDateDifference(item.updatedAt!!, Date())}D")
+                .also{ binding.textViewLastUpdated.text = it }
+        }
+
+        private fun getDateDifference(startDate: Date, endDate: Date): Long {
+            return TimeUnit.DAYS.convert(endDate.time - startDate.time,
+                TimeUnit.MILLISECONDS)
         }
 
         companion object {

--- a/app/src/main/java/com/example/sharingang/ui/adapters/ItemsAdapter.kt
+++ b/app/src/main/java/com/example/sharingang/ui/adapters/ItemsAdapter.kt
@@ -17,8 +17,9 @@ import java.util.concurrent.TimeUnit
 /**
  * Adapter to display items in a recycler view.
  * @property[clickListener] an item listener
+ * @property context the context
  */
-class ItemsAdapter(private val clickListener: ItemListener) :
+class ItemsAdapter(private val clickListener: ItemListener, private val context: Context) :
     ListAdapter<Item, ItemsAdapter.ItemViewHolder>(ItemsDiffCallback()) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ItemViewHolder {
@@ -32,26 +33,27 @@ class ItemsAdapter(private val clickListener: ItemListener) :
     /**
      * Recycler view to represent a single item.
      * @property binding item view binding
+     * @property context the context
      */
-    class ItemViewHolder private constructor(private val binding: ItemViewBinding) :
+    class ItemViewHolder private constructor(private val binding: ItemViewBinding,
+                                             private val context: Context) :
         RecyclerView.ViewHolder(binding.root) {
 
         fun bind(item: Item, clickListener: ItemListener) {
             binding.itemListViewTitle.text = item.title
             binding.item = item
+            val dateHelper = DateHelper(context)
             Glide.with(binding.itemImagePreview).load(item.image).into(binding.itemImagePreview)
             binding.clickListener = clickListener
             binding.textViewLastUpdated.text =
-                DateHelper.getDateDifferenceString(
-                    startDate = item.updatedAt!!, endDate = Date()
-                )
+                dateHelper.getDateDifferenceString(startDate = item.updatedAt!!, endDate = Date())
         }
 
         companion object {
             fun from(parent: ViewGroup): ItemViewHolder {
                 val layoutInflater = LayoutInflater.from(parent.context)
                 val binding = ItemViewBinding.inflate(layoutInflater, parent, false)
-                return ItemViewHolder(binding)
+                return ItemViewHolder(binding, parent.context)
             }
         }
     }

--- a/app/src/main/java/com/example/sharingang/ui/adapters/ItemsAdapter.kt
+++ b/app/src/main/java/com/example/sharingang/ui/adapters/ItemsAdapter.kt
@@ -41,8 +41,10 @@ class ItemsAdapter(private val clickListener: ItemListener) :
             binding.item = item
             Glide.with(binding.itemImagePreview).load(item.image).into(binding.itemImagePreview)
             binding.clickListener = clickListener
-            ("${DateHelper.getDateDifferenceInDays(item.updatedAt!!, Date())}D")
-                .also{ binding.textViewLastUpdated.text = it }
+            binding.textViewLastUpdated.text =
+                DateHelper.getDateDifferenceString(
+                    startDate = item.updatedAt!!, endDate = Date()
+                )
         }
 
         companion object {

--- a/app/src/main/java/com/example/sharingang/ui/fragments/DetailedItemFragment.kt
+++ b/app/src/main/java/com/example/sharingang/ui/fragments/DetailedItemFragment.kt
@@ -298,8 +298,9 @@ class DetailedItemFragment : Fragment() {
     private fun setLastUpdated() {
         lifecycleScope.launch(Dispatchers.IO) {
             val lastUpdate = itemRepository.getLastTimeUpdate(args.item.id!!)
+            val dateHelper = DateHelper(requireContext())
             lifecycleScope.launch(Dispatchers.Main) {
-                binding.lastUpdateText.text = DateHelper.getDateDifferenceString(
+                binding.lastUpdateText.text = dateHelper.getDateDifferenceString(
                     startDate = lastUpdate, endDate = Date()
                 )
             }

--- a/app/src/main/java/com/example/sharingang/ui/fragments/DetailedItemFragment.kt
+++ b/app/src/main/java/com/example/sharingang/ui/fragments/DetailedItemFragment.kt
@@ -191,7 +191,9 @@ class DetailedItemFragment : Fragment() {
     private fun initWishlistButton() {
         if (currentUserProvider.getCurrentUserId() != null && !args.item.request) {
             viewModel.wishlistContains.observe(viewLifecycleOwner, {
-                binding.addToWishlist.text = getButtonText(it)
+                binding.addToWishlist.text =
+                    if(it) getString(R.string.remove_wishlist)
+                    else getString(R.string.add_wishlist)
             })
             binding.addToWishlist.setOnClickListener { updateWishlist() }
             viewModel.wishlistContains(args.item)
@@ -223,12 +225,6 @@ class DetailedItemFragment : Fragment() {
                 itemViewModel.rateItem(item)
             }
         }
-    }
-
-
-    private fun getButtonText(contains: Boolean): String {
-        return if (contains) getString(R.string.remove_wishlist)
-        else getString(R.string.add_wishlist)
     }
 
     private fun updateWishlist() {

--- a/app/src/main/java/com/example/sharingang/ui/fragments/DetailedItemFragment.kt
+++ b/app/src/main/java/com/example/sharingang/ui/fragments/DetailedItemFragment.kt
@@ -299,11 +299,9 @@ class DetailedItemFragment : Fragment() {
         lifecycleScope.launch(Dispatchers.IO) {
             val lastUpdate = itemRepository.getLastTimeUpdate(args.item.id!!)
             lifecycleScope.launch(Dispatchers.Main) {
-                binding.lastUpdateText.text =
-                    getString(
-                        R.string.last_update,
-                        DateHelper.getDateDifferenceInDays(Date(), lastUpdate).toString()
-                    )
+                binding.lastUpdateText.text = DateHelper.getDateDifferenceString(
+                    startDate = lastUpdate, endDate = Date()
+                )
             }
         }
     }

--- a/app/src/main/java/com/example/sharingang/ui/fragments/DetailedItemFragment.kt
+++ b/app/src/main/java/com/example/sharingang/ui/fragments/DetailedItemFragment.kt
@@ -32,6 +32,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import android.graphics.Paint
+import com.example.sharingang.utils.DateHelper
+import java.util.*
 
 @AndroidEntryPoint
 class DetailedItemFragment : Fragment() {
@@ -86,6 +88,7 @@ class DetailedItemFragment : Fragment() {
 
         viewModel.setUser(args.item.userId)
         viewModel.user.observe(viewLifecycleOwner, this::onUserChange)
+        binding.lastUpdateText.text = DateHelper.getDateDifferenceInDays(Date(), item!!.updatedAt!!).toString()
         return binding.root
     }
 

--- a/app/src/main/java/com/example/sharingang/ui/fragments/DetailedItemFragment.kt
+++ b/app/src/main/java/com/example/sharingang/ui/fragments/DetailedItemFragment.kt
@@ -88,7 +88,7 @@ class DetailedItemFragment : Fragment() {
 
         viewModel.setUser(args.item.userId)
         viewModel.user.observe(viewLifecycleOwner, this::onUserChange)
-        binding.lastUpdateText.text = DateHelper.getDateDifferenceInDays(Date(), item!!.updatedAt!!).toString()
+        setLastUpdated()
         return binding.root
     }
 
@@ -293,6 +293,22 @@ class DetailedItemFragment : Fragment() {
             view?.findNavController()?.navigate(
                 DetailedItemFragmentDirections.actionDetailedItemFragmentToARActivity(it)
             )
+        }
+    }
+
+    /**
+     * Sets the text for when the item was last updated
+     */
+    private fun setLastUpdated() {
+        lifecycleScope.launch(Dispatchers.IO) {
+            val lastUpdate = itemRepository.getLastTimeUpdate(args.item.id!!)
+            lifecycleScope.launch(Dispatchers.Main) {
+                binding.lastUpdateText.text =
+                    getString(
+                        R.string.last_update,
+                        DateHelper.getDateDifferenceInDays(Date(), lastUpdate).toString()
+                    )
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/sharingang/ui/fragments/ItemsListFragment.kt
+++ b/app/src/main/java/com/example/sharingang/ui/fragments/ItemsListFragment.kt
@@ -11,6 +11,9 @@ import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.GridLayoutManager
 import com.example.sharingang.R
 import com.example.sharingang.databinding.FragmentItemsListBinding
+import com.example.sharingang.models.Item
+import com.example.sharingang.ui.adapters.ItemListener
+import com.example.sharingang.ui.adapters.ItemsAdapter
 import com.example.sharingang.viewmodels.ItemsViewModel
 import com.example.sharingang.viewmodels.OrderingViewModel
 
@@ -27,7 +30,8 @@ class ItemsListFragment : Fragment() {
         binding = DataBindingUtil.inflate(inflater, R.layout.fragment_items_list, container, false)
         binding.viewModel = viewModel
 
-        val adapter = viewModel.setupItemAdapter()
+
+        val adapter = setupItemAdapter()
         binding.itemList.adapter = adapter
         viewModel.addObserver(viewLifecycleOwner, adapter, ItemsViewModel.OBSERVABLES.ORDERED_ITEMS)
         binding.itemList.layoutManager = GridLayoutManager(context, 2)
@@ -57,6 +61,14 @@ class ItemsListFragment : Fragment() {
             ItemsViewModel.ORDERING.values()[binding.orderCategorySpinner.selectedItemPosition],
             binding.orderAscendingDescending.selectedItemPosition == 0
         )
+    }
+
+    /**
+     * Setup the item adapter for a recycler view.
+     */
+    private fun setupItemAdapter(): ItemsAdapter {
+        val onView = { item: Item -> viewModel.onViewItem(item) }
+        return ItemsAdapter(ItemListener(onView), requireContext())
     }
 }
 

--- a/app/src/main/java/com/example/sharingang/ui/fragments/NewEditFragment.kt
+++ b/app/src/main/java/com/example/sharingang/ui/fragments/NewEditFragment.kt
@@ -35,6 +35,7 @@ import com.google.android.libraries.places.widget.AutocompleteSupportFragment
 import com.google.android.libraries.places.widget.listener.PlaceSelectionListener
 import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
+import java.util.*
 import javax.inject.Inject
 
 /**
@@ -213,7 +214,8 @@ class NewEditFragment : Fragment() {
             localId = existingItem?.localId ?: 0,
             request = binding.switchIsRequest.isChecked,
             discount = binding.switchIsDiscount.isChecked,
-            discountPrice = binding.priceDiscount?.toDoubleOrNull() ?: 0.0
+            discountPrice = binding.priceDiscount?.toDoubleOrNull() ?: 0.0,
+            updatedAt = Date()
         )
     }
 

--- a/app/src/main/java/com/example/sharingang/ui/fragments/SearchFragment.kt
+++ b/app/src/main/java/com/example/sharingang/ui/fragments/SearchFragment.kt
@@ -12,6 +12,9 @@ import com.example.sharingang.R
 import com.example.sharingang.databinding.FragmentSearchBinding
 import com.example.sharingang.viewmodels.ItemsViewModel
 import com.example.sharingang.auth.CurrentUserProvider
+import com.example.sharingang.models.Item
+import com.example.sharingang.ui.adapters.ItemListener
+import com.example.sharingang.ui.adapters.ItemsAdapter
 import com.example.sharingang.viewmodels.UserProfileViewModel
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -37,7 +40,7 @@ class SearchFragment : Fragment(), AdapterView.OnItemSelectedListener {
         savedInstanceState: Bundle?
     ): View {
         binding = DataBindingUtil.inflate(inflater, R.layout.fragment_search, container, false)
-        val adapter = viewModel.setupItemAdapter()
+        val adapter = setupItemAdapter()
         setupToolbar()
         binding.itemSearchList.adapter = adapter
         binding.itemSearchList.layoutManager = GridLayoutManager(context, 2)
@@ -126,6 +129,14 @@ class SearchFragment : Fragment(), AdapterView.OnItemSelectedListener {
             contained = it
             activity?.invalidateOptionsMenu()
         })
+    }
+
+    /**
+    * Setup the item adapter for a recycler view.
+    */
+    private fun setupItemAdapter(): ItemsAdapter {
+        val onView = { item: Item -> viewModel.onViewItem(item) }
+        return ItemsAdapter(ItemListener(onView), requireContext())
     }
 
 }

--- a/app/src/main/java/com/example/sharingang/ui/fragments/SoldItemList.kt
+++ b/app/src/main/java/com/example/sharingang/ui/fragments/SoldItemList.kt
@@ -12,6 +12,9 @@ import com.example.sharingang.R
 import com.example.sharingang.databinding.FragmentSoldItemListBinding
 import com.example.sharingang.viewmodels.ItemsViewModel
 import com.example.sharingang.auth.CurrentUserProvider
+import com.example.sharingang.models.Item
+import com.example.sharingang.ui.adapters.ItemListener
+import com.example.sharingang.ui.adapters.ItemsAdapter
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -40,7 +43,7 @@ class SoldItemList : Fragment() {
     }
 
     private fun setupRecyclerview() {
-        val adapter = viewModel.setupItemAdapter()
+        val adapter = setupItemAdapter()
         binding.soldList.adapter = adapter
         viewModel.getUserSoldItems(currentUserProvider.getCurrentUserId())
         viewModel.addObserver(viewLifecycleOwner, adapter, ItemsViewModel.OBSERVABLES.SOLD_ITEMS)
@@ -48,6 +51,14 @@ class SoldItemList : Fragment() {
             {
                 SoldItemListDirections.actionSoldItemListToDetailedItemFragment(it)
             })
+    }
+
+    /**
+    * Setup the item adapter for a recycler view.
+    */
+    private fun setupItemAdapter(): ItemsAdapter {
+        val onView = { item: Item -> viewModel.onViewItem(item) }
+        return ItemsAdapter(ItemListener(onView), requireContext())
     }
 
 }

--- a/app/src/main/java/com/example/sharingang/ui/fragments/UserProfileFragment.kt
+++ b/app/src/main/java/com/example/sharingang/ui/fragments/UserProfileFragment.kt
@@ -143,7 +143,7 @@ class UserProfileFragment : Fragment() {
         setupRecyclerView(shownUserProfileId)
         setupAuthenticationButtons()
         initSetup()
-        setEmailText()
+        if (userType == UserType.SELF) binding.textEmail.text = loggedInUserEmail
         setVisibilities()
         setupViews()
         setupReportButton()
@@ -226,11 +226,6 @@ class UserProfileFragment : Fragment() {
             })
     }
 
-    private fun setEmailText() {
-        val emailText = binding.textEmail
-        if (userType == UserType.SELF) emailText.text = loggedInUserEmail
-    }
-
     private fun setupViews() {
         val buttons = listOf(
             binding.btnOpenCamera, binding.btnOpenGallery
@@ -241,7 +236,7 @@ class UserProfileFragment : Fragment() {
             else imageAccess.openCamera()
         } }
         topInfo.text = getString(R.string.userNotLoggedInInfo)
-        setEmailText()
+        if (userType == UserType.SELF) binding.textEmail.text = loggedInUserEmail
     }
 
     private fun displayUserFields(requestedUser: User?) {
@@ -251,7 +246,7 @@ class UserProfileFragment : Fragment() {
             val userPictureUri = requestedUser.profilePicture
             val userProfilePicture = binding.imageView
             Glide.with(this).load(userPictureUri).into(userProfilePicture)
-            setEmailText()
+            if (userType == UserType.SELF) binding.textEmail.text = loggedInUserEmail
         }
     }
 

--- a/app/src/main/java/com/example/sharingang/ui/fragments/UserProfileFragment.kt
+++ b/app/src/main/java/com/example/sharingang/ui/fragments/UserProfileFragment.kt
@@ -19,6 +19,9 @@ import com.example.sharingang.auth.CurrentUserProvider
 import com.example.sharingang.models.User
 import com.example.sharingang.database.repositories.UserRepository
 import com.example.sharingang.imagestore.ImageStore
+import com.example.sharingang.models.Item
+import com.example.sharingang.ui.adapters.ItemListener
+import com.example.sharingang.ui.adapters.ItemsAdapter
 import com.example.sharingang.utils.ImageAccess
 import com.example.sharingang.viewmodels.UserProfileViewModel
 import com.firebase.ui.auth.AuthUI
@@ -202,7 +205,7 @@ class UserProfileFragment : Fragment() {
     }
 
     private fun setupRecyclerView(userId: String?) {
-        val adapter = itemsViewModel.setupItemAdapter()
+        val adapter = setupItemAdapter()
         binding.userItemList.adapter = adapter
         listOf(binding.offersButton, binding.requestsButton).forEach {
             it.setOnClickListener {
@@ -331,5 +334,13 @@ class UserProfileFragment : Fragment() {
             binding.imageView.setImageURI(currentImageUri)
             changeImage(currentImageUri)
         }
+    }
+
+    /**
+    * Setup the item adapter for a recycler view.
+    */
+    private fun setupItemAdapter(): ItemsAdapter {
+        val onView = { item: Item -> itemsViewModel.onViewItem(item) }
+        return ItemsAdapter(ItemListener(onView), requireContext())
     }
 }

--- a/app/src/main/java/com/example/sharingang/ui/fragments/WishlistViewFragment.kt
+++ b/app/src/main/java/com/example/sharingang/ui/fragments/WishlistViewFragment.kt
@@ -12,6 +12,9 @@ import androidx.recyclerview.widget.GridLayoutManager
 import com.example.sharingang.databinding.FragmentWishlistViewBinding
 import com.example.sharingang.viewmodels.ItemsViewModel
 import com.example.sharingang.auth.CurrentUserProvider
+import com.example.sharingang.models.Item
+import com.example.sharingang.ui.adapters.ItemListener
+import com.example.sharingang.ui.adapters.ItemsAdapter
 import com.example.sharingang.viewmodels.UserProfileViewModel
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -37,7 +40,7 @@ class WishlistViewFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View {
         binding = FragmentWishlistViewBinding.inflate(inflater, container, false)
-        val adapter = viewModel.setupItemAdapter()
+        val adapter = setupItemAdapter()
         binding.wishlistview.adapter = adapter
         binding.wishlistview.layoutManager = GridLayoutManager(context, 2)
         viewModel.addObserver(viewLifecycleOwner, adapter, ItemsViewModel.OBSERVABLES.WISHLIST)
@@ -56,5 +59,13 @@ class WishlistViewFragment : Fragment() {
 
     private fun checkUser() {
         binding.isAuthenticated = currentUserProvider.getCurrentUserId() != null
+    }
+
+    /**
+    * Setup the item adapter for a recycler view.
+    */
+    private fun setupItemAdapter(): ItemsAdapter {
+        val onView = { item: Item -> viewModel.onViewItem(item) }
+        return ItemsAdapter(ItemListener(onView), requireContext())
     }
 }

--- a/app/src/main/java/com/example/sharingang/utils/DateHelper.kt
+++ b/app/src/main/java/com/example/sharingang/utils/DateHelper.kt
@@ -1,6 +1,8 @@
 package com.example.sharingang.utils
 
 import android.annotation.SuppressLint
+import android.content.Context
+import com.example.sharingang.R
 import java.text.ParseException
 import java.text.SimpleDateFormat
 import java.util.*
@@ -8,8 +10,9 @@ import java.util.concurrent.TimeUnit
 
 /**
  * Helper for date calculations and time formatting
+ * @property context the context
  */
-object DateHelper {
+class DateHelper(private val context: Context) {
 
     /**
      * Contains units of measure for time
@@ -25,13 +28,13 @@ object DateHelper {
     }
 
     private val unitStringMap = hashMapOf (
-        Measure.SECONDS to "s",
-        Measure.MINUTES to "min",
-        Measure.HOURS to "h",
-        Measure.DAYS to "d",
-        Measure.WEEKS to "w",
-        Measure.MONTHS to "mon",
-        Measure.YEARS to "y"
+        Measure.SECONDS to context.getString(R.string.eng_seconds),
+        Measure.MINUTES to context.getString(R.string.eng_minutes),
+        Measure.HOURS to context.getString(R.string.eng_hours),
+        Measure.DAYS to context.getString(R.string.eng_days),
+        Measure.WEEKS to context.getString(R.string.eng_weeks),
+        Measure.MONTHS to context.getString(R.string.eng_months),
+        Measure.YEARS to context.getString(R.string.eng_years)
     )
 
     /*
@@ -40,12 +43,12 @@ object DateHelper {
      * implementation will do (as it is used for the last time an item was updated for example,
      * which does not require a very precise estimation of time.)
      */
-    private const val SECS_PER_MINUTE = 60L
-    private const val SECS_PER_HOUR = 3600L
-    private const val SECS_PER_DAY = 86400L
-    private const val DAYS_PER_WEEK = 7L
-    private const val DAYS_PER_MONTH = 30L
-    private const val DAYS_PER_YEAR = 365L
+    private val SECS_PER_MINUTE = 60L
+    private val SECS_PER_HOUR = 3600L
+    private val SECS_PER_DAY = 86400L
+    private val DAYS_PER_WEEK = 7L
+    private val DAYS_PER_MONTH = 30L
+    private val DAYS_PER_YEAR = 365L
 
 
     /**
@@ -124,7 +127,7 @@ object DateHelper {
      */
     @SuppressLint("SimpleDateFormat")
     fun createDate(dateStr: String): Date? {
-        val dateFormat = SimpleDateFormat("yyyy/MM/dd HH:mm:ss")
+        val dateFormat = SimpleDateFormat(context.getString(R.string.dateCreationFormat))
         return try {
             dateFormat.parse(dateStr)
         } catch (e: ParseException) {

--- a/app/src/main/java/com/example/sharingang/utils/DateHelper.kt
+++ b/app/src/main/java/com/example/sharingang/utils/DateHelper.kt
@@ -18,8 +18,8 @@ object DateHelper {
     /*
      * Note: It is true that days can differ between years and months. Here, we are only
      * concerned by an estimation of the time between two dates, which is why this very simplified
-     * implementation will do (used for the last time an item was updated for example, which does
-     * not require a very precise measure of time.)
+     * implementation will do (as it is used for the last time an item was updated for example,
+     * which does not require a very precise estimation of time.)
      */
     private const val SECS_PER_MINUTE = 60L
     private const val SECS_PER_HOUR = 3600L

--- a/app/src/main/java/com/example/sharingang/utils/DateHelper.kt
+++ b/app/src/main/java/com/example/sharingang/utils/DateHelper.kt
@@ -70,15 +70,15 @@ object DateHelper {
         val diffNumber = difference.first
         val measureStr =
             when(difference.second) {
-                Measure.SECONDS -> if(diffNumber == 1L) "second" else "seconds"
-                Measure.MINUTES -> if(diffNumber == 1L) "minute" else "minutes"
-                Measure.HOURS -> if(diffNumber == 1L) "hour" else "hours"
-                Measure.DAYS -> if(diffNumber == 1L) "day" else "days"
-                Measure.WEEKS -> if(diffNumber == 1L) "week" else "weeks"
-                Measure.MONTHS -> if(diffNumber == 1L) "month" else "months"
-                Measure.YEARS -> if(diffNumber == 1L) "year" else "years"
+                Measure.SECONDS -> "s"
+                Measure.MINUTES -> "min"
+                Measure.HOURS -> "h"
+                Measure.DAYS -> "d"
+                Measure.WEEKS -> "w"
+                Measure.MONTHS -> "mon"
+                Measure.YEARS -> "y"
             }
-        return "$diffNumber $measureStr"
+        return "$diffNumber$measureStr"
     }
 
 }

--- a/app/src/main/java/com/example/sharingang/utils/DateHelper.kt
+++ b/app/src/main/java/com/example/sharingang/utils/DateHelper.kt
@@ -24,6 +24,16 @@ object DateHelper {
         YEARS
     }
 
+    private val unitStringMap = hashMapOf (
+        Measure.SECONDS to "s",
+        Measure.MINUTES to "min",
+        Measure.HOURS to "h",
+        Measure.DAYS to "d",
+        Measure.WEEKS to "w",
+        Measure.MONTHS to "mon",
+        Measure.YEARS to "y"
+    )
+
     /*
      * Note: It is true that days can differ between years and months. Here, we are only
      * concerned by an estimation of the time between two dates, which is why this very simplified
@@ -48,18 +58,16 @@ object DateHelper {
      * @return the formatted difference between the two dates
      */
     fun getDateDifferenceString(startDate: Date, endDate: Date): String {
-        val endTime = endDate.time
-        val startTime = startDate.time
-        val diffInSeconds = TimeUnit.SECONDS.convert(endTime - startTime,
+        val end = endDate.time
+        val start = startDate.time
+        val timeDiff = end - start
+        val diffInSeconds = TimeUnit.SECONDS.convert(timeDiff,
             TimeUnit.MILLISECONDS)
         val lessThanADay = diffInSeconds < SECS_PER_DAY
         val accurateDiff =
-            if(lessThanADay) getAccurateDiffFromSeconds(diffInSeconds)
-            else {
-                val diffInDays =
-                    TimeUnit.DAYS.convert(endTime - startTime, TimeUnit.MILLISECONDS)
-                getAccurateDiffFromDays(diffInDays)
-            }
+            if(lessThanADay) getDiffFromSeconds(diffInSeconds)
+            else getDiffFromDays(TimeUnit.DAYS.convert(timeDiff, TimeUnit.MILLISECONDS))
+
         return getFormattedDifference(accurateDiff)
     }
 
@@ -69,7 +77,7 @@ object DateHelper {
      * @param diffInSeconds the difference in seconds
      * @return a pair containing the difference number and its unit of measure
      */
-    private fun getAccurateDiffFromSeconds(diffInSeconds: Long): Pair<Long, Measure> {
+    private fun getDiffFromSeconds(diffInSeconds: Long): Pair<Long, Measure> {
         return (
             when {
                 diffInSeconds < SECS_PER_MINUTE -> Pair(diffInSeconds, Measure.SECONDS)
@@ -85,7 +93,7 @@ object DateHelper {
      * @param diffInDays the difference in days
      * @return a pair containing the difference number and its unit of measure
      */
-    private fun getAccurateDiffFromDays(diffInDays: Long): Pair<Long, Measure> {
+    private fun getDiffFromDays(diffInDays: Long): Pair<Long, Measure> {
         return (
             when {
                 diffInDays < DAYS_PER_WEEK -> Pair(diffInDays, Measure.DAYS)
@@ -104,16 +112,7 @@ object DateHelper {
      */
     private fun getFormattedDifference(time: Pair<Long, Measure>): String {
         val diffNumber = time.first
-        val measureStr =
-            when(time.second) {
-                Measure.SECONDS -> "s"
-                Measure.MINUTES -> "min"
-                Measure.HOURS -> "h"
-                Measure.DAYS -> "d"
-                Measure.WEEKS -> "w"
-                Measure.MONTHS -> "mon"
-                Measure.YEARS -> "y"
-            }
+        val measureStr = unitStringMap[time.second]
         return "$diffNumber$measureStr"
     }
 

--- a/app/src/main/java/com/example/sharingang/utils/DateHelper.kt
+++ b/app/src/main/java/com/example/sharingang/utils/DateHelper.kt
@@ -1,0 +1,12 @@
+package com.example.sharingang.utils
+
+import java.util.*
+import java.util.concurrent.TimeUnit
+
+object DateHelper {
+    fun getDateDifferenceInDays(startDate: Date, endDate: Date): Long {
+        return TimeUnit.DAYS.convert(endDate.time - startDate.time,
+            TimeUnit.MILLISECONDS)
+    }
+
+}

--- a/app/src/main/java/com/example/sharingang/utils/DateHelper.kt
+++ b/app/src/main/java/com/example/sharingang/utils/DateHelper.kt
@@ -3,8 +3,14 @@ package com.example.sharingang.utils
 import java.util.*
 import java.util.concurrent.TimeUnit
 
+/**
+ * Helper for date calculations and time formatting
+ */
 object DateHelper {
 
+    /**
+     * Contains units of measure for time
+     */
     enum class Measure {
         SECONDS,
         MINUTES,
@@ -29,6 +35,15 @@ object DateHelper {
     private const val DAYS_PER_YEAR = 365L
 
 
+    /**
+     * Gives us the formatted difference between two dates depending on how far the two dates
+     * are from each other. Close dates will give us a result in seconds or minutes or hours,
+     * and dates that are far from each other will give us one in days, weeks, months or years.
+     *
+     * @param startDate the date from which we start counting
+     * @param endDate the date at which we stop counting
+     * @return the formatted difference between the two dates
+     */
     fun getDateDifferenceString(startDate: Date, endDate: Date): String {
         val endTime = endDate.time
         val startTime = startDate.time
@@ -45,6 +60,12 @@ object DateHelper {
         return getFormattedDifference(accurateDiff)
     }
 
+    /**
+     * Gives us an accurate difference based on the time difference in seconds
+     *
+     * @param diffInSeconds the difference in seconds
+     * @return a pair containing the difference number and its unit of measure
+     */
     private fun getAccurateDiffFromSeconds(diffInSeconds: Long): Pair<Long, Measure> {
         return (
             when {
@@ -55,6 +76,12 @@ object DateHelper {
         )
     }
 
+    /**
+     * Gives us an accurate difference based on the time difference in days
+     *
+     * @param diffInDays the difference in days
+     * @return a pair containing the difference number and its unit of measure
+     */
     private fun getAccurateDiffFromDays(diffInDays: Long): Pair<Long, Measure> {
         return (
             when {
@@ -66,10 +93,16 @@ object DateHelper {
         )
     }
 
-    private fun getFormattedDifference(difference: Pair<Long, Measure>): String {
-        val diffNumber = difference.first
+    /**
+     * Gives us a formatted time based on a number and its unit of measure
+     *
+     * @param time a pair containing the number and its unit of measure
+     * @return the formatted result
+     */
+    private fun getFormattedDifference(time: Pair<Long, Measure>): String {
+        val diffNumber = time.first
         val measureStr =
-            when(difference.second) {
+            when(time.second) {
                 Measure.SECONDS -> "s"
                 Measure.MINUTES -> "min"
                 Measure.HOURS -> "h"

--- a/app/src/main/java/com/example/sharingang/utils/DateHelper.kt
+++ b/app/src/main/java/com/example/sharingang/utils/DateHelper.kt
@@ -8,12 +8,13 @@ import java.text.ParseException
 import java.text.SimpleDateFormat
 import java.util.*
 import java.util.concurrent.TimeUnit
+import kotlin.collections.HashMap
 
 /**
  * Helper for date calculations and time formatting
  * @property context the context
  */
-class DateHelper(private val context: Context) {
+class DateHelper(private val context: Context?) {
 
     /**
      * Contains units of measure for time
@@ -28,15 +29,16 @@ class DateHelper(private val context: Context) {
         YEARS
     }
 
-    private val unitStringMap = hashMapOf (
-        Measure.SECONDS to context.getString(R.string.eng_seconds),
-        Measure.MINUTES to context.getString(R.string.eng_minutes),
-        Measure.HOURS to context.getString(R.string.eng_hours),
-        Measure.DAYS to context.getString(R.string.eng_days),
-        Measure.WEEKS to context.getString(R.string.eng_weeks),
-        Measure.MONTHS to context.getString(R.string.eng_months),
-        Measure.YEARS to context.getString(R.string.eng_years)
-    )
+    private var unitStringMap: HashMap<Measure, String>? =
+        hashMapOf(
+            Measure.SECONDS to (context?.getString(R.string.eng_seconds) ?: "s"),
+            Measure.MINUTES to (context?.getString(R.string.eng_seconds) ?: "min"),
+            Measure.HOURS to (context?.getString(R.string.eng_seconds) ?: "h"),
+            Measure.DAYS to (context?.getString(R.string.eng_seconds) ?: "d"),
+            Measure.WEEKS to (context?.getString(R.string.eng_seconds) ?: "w"),
+            Measure.MONTHS to (context?.getString(R.string.eng_seconds) ?: "mon"),
+            Measure.YEARS to (context?.getString(R.string.eng_seconds) ?: "y"),
+        )
 
     /*
      * Note: It is true that days can differ between years and months. Here, we are only
@@ -116,7 +118,7 @@ class DateHelper(private val context: Context) {
      */
     private fun getFormattedDifference(time: Pair<Long, Measure>): String {
         val diffNumber = time.first
-        val measureStr = unitStringMap[time.second]
+        val measureStr = unitStringMap!![time.second]
         return "$diffNumber$measureStr"
     }
 
@@ -131,5 +133,6 @@ class DateHelper(private val context: Context) {
         return SimpleDateFormat(format).parse(dateStr)
 
     }
+
 
 }

--- a/app/src/main/java/com/example/sharingang/utils/DateHelper.kt
+++ b/app/src/main/java/com/example/sharingang/utils/DateHelper.kt
@@ -2,6 +2,7 @@ package com.example.sharingang.utils
 
 import android.annotation.SuppressLint
 import android.content.Context
+import androidx.test.platform.app.InstrumentationRegistry
 import com.example.sharingang.R
 import java.text.ParseException
 import java.text.SimpleDateFormat
@@ -127,12 +128,7 @@ class DateHelper(private val context: Context) {
      */
     @SuppressLint("SimpleDateFormat")
     fun createDate(dateStr: String): Date? {
-        val dateFormat = SimpleDateFormat(context.getString(R.string.dateCreationFormat))
-        return try {
-            dateFormat.parse(dateStr)
-        } catch (e: ParseException) {
-            null
-        }
+        return SimpleDateFormat(context.getString(R.string.dateCreationFormat)).parse(dateStr)
 
     }
 

--- a/app/src/main/java/com/example/sharingang/utils/DateHelper.kt
+++ b/app/src/main/java/com/example/sharingang/utils/DateHelper.kt
@@ -2,9 +2,7 @@ package com.example.sharingang.utils
 
 import android.annotation.SuppressLint
 import android.content.Context
-import androidx.test.platform.app.InstrumentationRegistry
 import com.example.sharingang.R
-import java.text.ParseException
 import java.text.SimpleDateFormat
 import java.util.*
 import java.util.concurrent.TimeUnit

--- a/app/src/main/java/com/example/sharingang/utils/DateHelper.kt
+++ b/app/src/main/java/com/example/sharingang/utils/DateHelper.kt
@@ -4,9 +4,81 @@ import java.util.*
 import java.util.concurrent.TimeUnit
 
 object DateHelper {
-    fun getDateDifferenceInDays(startDate: Date, endDate: Date): Long {
-        return TimeUnit.DAYS.convert(endDate.time - startDate.time,
+
+    enum class Measure {
+        SECONDS,
+        MINUTES,
+        HOURS,
+        DAYS,
+        WEEKS,
+        MONTHS,
+        YEARS
+    }
+
+    /*
+     * Note: It is true that days can differ between years and months. Here, we are only
+     * concerned by an estimation of the time between two dates, which is why this very simplified
+     * implementation will do (used for the last time an item was updated for example, which does
+     * not require a very precise measure of time.)
+     */
+    private const val SECS_PER_MINUTE = 60L
+    private const val SECS_PER_HOUR = 3600L
+    private const val SECS_PER_DAY = 86400L
+    private const val DAYS_PER_WEEK = 7L
+    private const val DAYS_PER_MONTH = 30L
+    private const val DAYS_PER_YEAR = 365L
+
+
+    fun getDateDifferenceString(startDate: Date, endDate: Date): String {
+        val endTime = endDate.time
+        val startTime = startDate.time
+        val diffInSeconds = TimeUnit.SECONDS.convert(endTime - startTime,
             TimeUnit.MILLISECONDS)
+        val lessThanADay = diffInSeconds < SECS_PER_DAY
+        val accurateDiff =
+            if(lessThanADay) getAccurateDiffFromSeconds(diffInSeconds)
+            else {
+                val diffInDays =
+                    TimeUnit.DAYS.convert(endTime - startTime, TimeUnit.MILLISECONDS)
+                getAccurateDiffFromDays(diffInDays)
+            }
+        return getFormattedDifference(accurateDiff)
+    }
+
+    private fun getAccurateDiffFromSeconds(diffInSeconds: Long): Pair<Long, Measure> {
+        return (
+            when {
+                diffInSeconds < SECS_PER_MINUTE -> Pair(diffInSeconds, Measure.SECONDS)
+                diffInSeconds < SECS_PER_HOUR -> Pair(diffInSeconds / SECS_PER_MINUTE, Measure.MINUTES)
+                else -> Pair(diffInSeconds / SECS_PER_DAY, Measure.HOURS)
+            }
+        )
+    }
+
+    private fun getAccurateDiffFromDays(diffInDays: Long): Pair<Long, Measure> {
+        return (
+            when {
+                diffInDays < DAYS_PER_WEEK -> Pair(diffInDays, Measure.DAYS)
+                diffInDays < DAYS_PER_MONTH -> Pair(diffInDays / DAYS_PER_WEEK, Measure.WEEKS)
+                diffInDays < DAYS_PER_YEAR -> Pair(diffInDays / DAYS_PER_MONTH, Measure.MONTHS)
+                else -> Pair(diffInDays / DAYS_PER_YEAR, Measure.YEARS)
+            }
+        )
+    }
+
+    private fun getFormattedDifference(difference: Pair<Long, Measure>): String {
+        val diffNumber = difference.first
+        val measureStr =
+            when(difference.second) {
+                Measure.SECONDS -> if(diffNumber == 1L) "second" else "seconds"
+                Measure.MINUTES -> if(diffNumber == 1L) "minute" else "minutes"
+                Measure.HOURS -> if(diffNumber == 1L) "hour" else "hours"
+                Measure.DAYS -> if(diffNumber == 1L) "day" else "days"
+                Measure.WEEKS -> if(diffNumber == 1L) "week" else "weeks"
+                Measure.MONTHS -> if(diffNumber == 1L) "month" else "months"
+                Measure.YEARS -> if(diffNumber == 1L) "year" else "years"
+            }
+        return "$diffNumber $measureStr"
     }
 
 }

--- a/app/src/main/java/com/example/sharingang/utils/DateHelper.kt
+++ b/app/src/main/java/com/example/sharingang/utils/DateHelper.kt
@@ -127,8 +127,8 @@ class DateHelper(private val context: Context) {
      * @return the created Date
      */
     @SuppressLint("SimpleDateFormat")
-    fun createDate(dateStr: String): Date? {
-        return SimpleDateFormat(context.getString(R.string.dateCreationFormat)).parse(dateStr)
+    fun createDate(format: String, dateStr: String): Date? {
+        return SimpleDateFormat(format).parse(dateStr)
 
     }
 

--- a/app/src/main/java/com/example/sharingang/utils/DateHelper.kt
+++ b/app/src/main/java/com/example/sharingang/utils/DateHelper.kt
@@ -1,5 +1,8 @@
 package com.example.sharingang.utils
 
+import android.annotation.SuppressLint
+import java.text.ParseException
+import java.text.SimpleDateFormat
 import java.util.*
 import java.util.concurrent.TimeUnit
 
@@ -71,7 +74,7 @@ object DateHelper {
             when {
                 diffInSeconds < SECS_PER_MINUTE -> Pair(diffInSeconds, Measure.SECONDS)
                 diffInSeconds < SECS_PER_HOUR -> Pair(diffInSeconds / SECS_PER_MINUTE, Measure.MINUTES)
-                else -> Pair(diffInSeconds / SECS_PER_DAY, Measure.HOURS)
+                else -> Pair(diffInSeconds / SECS_PER_HOUR, Measure.HOURS)
             }
         )
     }
@@ -112,6 +115,23 @@ object DateHelper {
                 Measure.YEARS -> "y"
             }
         return "$diffNumber$measureStr"
+    }
+
+    /**
+     * Creates a real Date from a formatted date and time
+     *
+     * @param dateStr date in format "yyyy/MM/dd HH:mm:ss"
+     * @return the created Date
+     */
+    @SuppressLint("SimpleDateFormat")
+    fun createDate(dateStr: String): Date? {
+        val dateFormat = SimpleDateFormat("yyyy/MM/dd HH:mm:ss")
+        return try {
+            dateFormat.parse(dateStr)
+        } catch (e: ParseException) {
+            null
+        }
+
     }
 
 }

--- a/app/src/main/java/com/example/sharingang/utils/constants/DatabaseFields.kt
+++ b/app/src/main/java/com/example/sharingang/utils/constants/DatabaseFields.kt
@@ -6,6 +6,8 @@ package com.example.sharingang.utils.constants
  */
 interface DatabaseFields {
     companion object {
+        const val DBFIELD_UPDATED_AT = "updatedAt"
+        const val DBFIELD_ITEMS = "items"
         const val DBFIELD_NUM_UNREAD = "numUnread"
         const val DBFIELD_MESSAGE = "message"
         const val DBFIELD_FROM = "from"

--- a/app/src/main/java/com/example/sharingang/viewmodels/ItemsViewModel.kt
+++ b/app/src/main/java/com/example/sharingang/viewmodels/ItemsViewModel.kt
@@ -212,7 +212,7 @@ class ItemsViewModel @Inject constructor(
         }
     }
 
-    private fun onViewItem(item: Item) {
+    fun onViewItem(item: Item) {
         _navigateToDetailItem.value = item
     }
 
@@ -242,14 +242,6 @@ class ItemsViewModel @Inject constructor(
         if (item != null) {
             onSellItem(item)
         }
-    }
-
-    /**
-     * Setup the item adapter for a recycle view.
-     */
-    fun setupItemAdapter(): ItemsAdapter {
-        val onView = { item: Item -> onViewItem(item) }
-        return ItemsAdapter(ItemListener(onView))
     }
 
     /**

--- a/app/src/main/res/layout/fragment_detailed_item.xml
+++ b/app/src/main/res/layout/fragment_detailed_item.xml
@@ -91,13 +91,14 @@
             tools:text="Here goes the description of the item." />
 
         <LinearLayout
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:gravity="center_vertical"
             android:orientation="horizontal">
 
             <TextView
                 android:id="@+id/textViewPostedBy"
-                android:layout_width="match_parent"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/posted_by"
                 android:textSize="18sp"
@@ -108,13 +109,35 @@
             <Button
                 android:id="@+id/itemPostedBy"
                 style="@style/Widget.MaterialComponents.Button.TextButton"
-                android:layout_width="match_parent"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:padding="5dp"
                 android:text="@{username}"
                 android:textColor="@color/themeColor"
                 android:textSize="18sp"
                 tools:text="TestUser" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="0"
+                android:gravity="right|center_vertical"
+                android:orientation="horizontal"
+                tools:ignore="InefficientWeight,RtlHardcoded,UseCompoundDrawables">
+
+                <ImageView
+                    android:id="@+id/updateImage"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    app:srcCompat="@android:drawable/ic_menu_recent_history"
+                    android:contentDescription="@string/lastUpdate" />
+
+                <TextView
+                    android:id="@+id/lastUpdateText"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/lastUpdate" />
+            </LinearLayout>
         </LinearLayout>
 
         <Button

--- a/app/src/main/res/layout/item_view.xml
+++ b/app/src/main/res/layout/item_view.xml
@@ -54,8 +54,8 @@
                 <LinearLayout
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="5dp"
-                    android:layout_marginEnd="20dp"
+                    android:layout_marginTop="1dp"
+                    android:layout_marginEnd="15dp"
                     android:gravity="center"
                     android:orientation="horizontal"
                     app:layout_constraintEnd_toEndOf="parent"
@@ -63,10 +63,10 @@
 
                     <ImageView
                         android:id="@+id/historyImage"
-                        android:layout_width="30dp"
-                        android:layout_height="30dp"
-                        app:srcCompat="@android:drawable/ic_menu_recent_history"
-                        android:contentDescription="@string/lastUpdate" />
+                        android:layout_width="25dp"
+                        android:layout_height="25dp"
+                        android:contentDescription="@string/lastUpdate"
+                        app:srcCompat="@android:drawable/ic_menu_recent_history" />
 
                     <TextView
                         android:id="@+id/textViewLastUpdated"

--- a/app/src/main/res/layout/item_view.xml
+++ b/app/src/main/res/layout/item_view.xml
@@ -63,8 +63,8 @@
 
                     <ImageView
                         android:id="@+id/historyImage"
-                        android:layout_width="25dp"
-                        android:layout_height="25dp"
+                        android:layout_width="15dp"
+                        android:layout_height="15dp"
                         android:contentDescription="@string/lastUpdate"
                         app:srcCompat="@android:drawable/ic_menu_recent_history" />
 
@@ -72,7 +72,7 @@
                         android:id="@+id/textViewLastUpdated"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:textSize="14sp" />
+                        android:textSize="12sp" />
                 </LinearLayout>
 
             </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_view.xml
+++ b/app/src/main/res/layout/item_view.xml
@@ -33,13 +33,49 @@
             android:layout_height="wrap_content"
             android:orientation="vertical">
 
-            <ImageView
-                android:id="@+id/item_image_preview"
+            <androidx.constraintlayout.widget.ConstraintLayout
                 android:layout_width="match_parent"
-                android:layout_height="100dp"
-                android:contentDescription="@string/item_image_description"
-                android:paddingTop="10dp"
-                android:src="@drawable/ic_baseline_image_24"/>
+                android:layout_height="0dp"
+                android:layout_weight="10">
+
+                <ImageView
+                    android:id="@+id/item_image_preview"
+                    android:layout_width="match_parent"
+                    android:layout_height="100dp"
+                    android:layout_weight="10"
+                    android:contentDescription="@string/item_image_description"
+                    android:paddingTop="10dp"
+                    android:src="@drawable/ic_baseline_image_24"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <LinearLayout
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="5dp"
+                    android:layout_marginEnd="20dp"
+                    android:gravity="center"
+                    android:orientation="horizontal"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="parent">
+
+                    <ImageView
+                        android:id="@+id/historyImage"
+                        android:layout_width="30dp"
+                        android:layout_height="30dp"
+                        app:srcCompat="@android:drawable/ic_menu_recent_history"
+                        android:contentDescription="@string/lastUpdate" />
+
+                    <TextView
+                        android:id="@+id/textViewLastUpdated"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:textSize="14sp" />
+                </LinearLayout>
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
 
             <TextView
                 android:id="@+id/item_list_view_title"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -99,6 +99,6 @@
     <string name="open_camera">Open Camera</string>
     <string name="is_discount">Discount?</string>
     <string name="discount_lower">Discount price must be lower</string>
-    <string name="last_update">%1$s D</string>
+    <string name="last_update">%1$sD</string>
     <string name="lastUpdate">lastUpdate</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -99,4 +99,6 @@
     <string name="open_camera">Open Camera</string>
     <string name="is_discount">Discount?</string>
     <string name="discount_lower">Discount price must be lower</string>
+    <string name="last_update">%1$s D</string>
+    <string name="lastUpdate">lastUpdate</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -99,6 +99,5 @@
     <string name="open_camera">Open Camera</string>
     <string name="is_discount">Discount?</string>
     <string name="discount_lower">Discount price must be lower</string>
-    <string name="last_update">%1$sD</string>
     <string name="lastUpdate">lastUpdate</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -100,4 +100,12 @@
     <string name="is_discount">Discount?</string>
     <string name="discount_lower">Discount price must be lower</string>
     <string name="lastUpdate">lastUpdate</string>
+    <string name="eng_seconds">s</string>
+    <string name="eng_minutes">min</string>
+    <string name="eng_hours">hours</string>
+    <string name="eng_days">d</string>
+    <string name="eng_weeks">w</string>
+    <string name="eng_months">mon</string>
+    <string name="eng_years">y</string>
+    <string name="dateCreationFormat">yyyy/MM/dd HH:mm:ss</string>
 </resources>

--- a/app/src/test/java/com/example/sharingang/utils/DateHelperTest.kt
+++ b/app/src/test/java/com/example/sharingang/utils/DateHelperTest.kt
@@ -1,14 +1,17 @@
 package com.example.sharingang.utils
 
+import android.content.Context
+import com.example.sharingang.ui.fragments.ItemsListFragment
 import junit.framework.Assert.assertEquals
 import org.junit.Test
+import org.junit.runner.manipulation.Ordering
 import java.text.DateFormat
 import java.text.SimpleDateFormat
 import java.util.*
 
 class DateHelperTest {
 
-    val dateHelper = DateHelper(null!!)
+    val dateHelper = DateHelper(null)
     val format = "yyyy/MM/dd HH:mm:ss"
 
     @Test

--- a/app/src/test/java/com/example/sharingang/utils/DateHelperTest.kt
+++ b/app/src/test/java/com/example/sharingang/utils/DateHelperTest.kt
@@ -1,0 +1,87 @@
+package com.example.sharingang.utils
+
+import junit.framework.Assert.assertEquals
+import org.junit.Test
+import java.text.DateFormat
+import java.text.SimpleDateFormat
+import java.util.*
+
+class DateHelperTest {
+
+    @Test
+    fun createDateIsCorrect() {
+        val now = Date()
+        val df: DateFormat = SimpleDateFormat("yyyy/MM/dd HH:mm:ss")
+        val dateString = df.format(now)
+        val createdDate = DateHelper.createDate(dateString)
+        assertEquals(now.toString(), createdDate.toString())
+    }
+
+    @Test
+    fun getDateDifferenceStringIsCorrectForSeconds() {
+        val customDate1 = DateHelper.createDate("2020/02/02 12:00:00")!!
+        val customDate2 = DateHelper.createDate("2020/02/02 12:00:01")!!
+        val customDate3 = DateHelper.createDate("2020/02/02 12:10:59")!!
+        val customDate4 = DateHelper.createDate("2020/02/02 12:11:09")!!
+        val difference12 = DateHelper.getDateDifferenceString(customDate1, customDate2)
+        val difference34 = DateHelper.getDateDifferenceString(customDate3, customDate4)
+        assertEquals("1s", difference12)
+        assertEquals("10s", difference34)
+    }
+
+    @Test
+    fun getDateDifferenceStringIsCorrectForMinutes() {
+        val customDate1 = DateHelper.createDate("2020/02/02 12:01:00")!!
+        val customDate2 = DateHelper.createDate("2020/02/02 12:05:00")!!
+        val customDate3 = DateHelper.createDate("2020/02/02 12:55:00")!!
+        val customDate4 = DateHelper.createDate("2020/02/02 13:05:00")!!
+        val difference12 = DateHelper.getDateDifferenceString(customDate1, customDate2)
+        val difference34 = DateHelper.getDateDifferenceString(customDate3, customDate4)
+        assertEquals("4min", difference12)
+        assertEquals("10min", difference34)
+    }
+
+    @Test
+    fun getDateDifferenceStringIsCorrectForHours() {
+        val customDate1 = DateHelper.createDate("2020/02/02 12:00:00")!!
+        val customDate2 = DateHelper.createDate("2020/02/02 13:00:00")!!
+        val customDate3 = DateHelper.createDate("2020/02/02 23:00:00")!!
+        val customDate4 = DateHelper.createDate("2020/02/03 04:00:00")!!
+        val difference12 = DateHelper.getDateDifferenceString(customDate1, customDate2)
+        val difference34 = DateHelper.getDateDifferenceString(customDate3, customDate4)
+        assertEquals("1h", difference12)
+        assertEquals("5h", difference34)
+    }
+
+    @Test
+    fun getDateDifferenceStringIsCorrectForWeeks() {
+        val customDate1 = DateHelper.createDate("2020/02/02 12:00:00")!!
+        val customDate2 = DateHelper.createDate("2020/02/09 12:00:00")!!
+        val customDate3 = DateHelper.createDate("2020/03/31 12:00:00")!!
+        val customDate4 = DateHelper.createDate("2020/04/07 12:00:00")!!
+        val difference12 = DateHelper.getDateDifferenceString(customDate1, customDate2)
+        val difference34 = DateHelper.getDateDifferenceString(customDate3, customDate4)
+        assertEquals("1w", difference12)
+        assertEquals("1w", difference34)
+    }
+
+    @Test
+    fun getDateDifferenceStringIsCorrectForMonths() {
+        val customDate1 = DateHelper.createDate("2020/05/02 12:00:00")!!
+        val customDate2 = DateHelper.createDate("2020/06/02 12:00:00")!!
+        val customDate3 = DateHelper.createDate("2020/12/01 12:00:00")!!
+        val customDate4 = DateHelper.createDate("2021/01/01 12:00:00")!!
+        val difference12 = DateHelper.getDateDifferenceString(customDate1, customDate2)
+        val difference34 = DateHelper.getDateDifferenceString(customDate3, customDate4)
+        assertEquals("1mon", difference12)
+        assertEquals("1mon", difference34)
+    }
+
+    @Test
+    fun getDateDifferenceStringIsCorrectForYears() {
+        val customDate1 = DateHelper.createDate("2020/02/02 12:00:00")!!
+        val customDate2 = DateHelper.createDate("2021/03/02 12:00:00")!!
+        val difference = DateHelper.getDateDifferenceString(customDate1, customDate2)
+        assertEquals("1y", difference)
+    }
+}

--- a/app/src/test/java/com/example/sharingang/utils/DateHelperTest.kt
+++ b/app/src/test/java/com/example/sharingang/utils/DateHelperTest.kt
@@ -8,80 +8,83 @@ import java.util.*
 
 class DateHelperTest {
 
+    val dateHelper = DateHelper(null!!)
+    val format = "yyyy/MM/dd HH:mm:ss"
+
     @Test
     fun createDateIsCorrect() {
         val now = Date()
-        val df: DateFormat = SimpleDateFormat("yyyy/MM/dd HH:mm:ss")
+        val df: DateFormat = SimpleDateFormat(format)
         val dateString = df.format(now)
-        val createdDate = DateHelper.createDate(dateString)
+        val createdDate = dateHelper.createDate(format, dateString)
         assertEquals(now.toString(), createdDate.toString())
     }
 
     @Test
     fun getDateDifferenceStringIsCorrectForSeconds() {
-        val customDate1 = DateHelper.createDate("2020/02/02 12:00:00")!!
-        val customDate2 = DateHelper.createDate("2020/02/02 12:00:01")!!
-        val customDate3 = DateHelper.createDate("2020/02/02 12:10:59")!!
-        val customDate4 = DateHelper.createDate("2020/02/02 12:11:09")!!
-        val difference12 = DateHelper.getDateDifferenceString(customDate1, customDate2)
-        val difference34 = DateHelper.getDateDifferenceString(customDate3, customDate4)
+        val customDate1 = dateHelper.createDate(format,"2020/02/02 12:00:00")!!
+        val customDate2 = dateHelper.createDate(format,"2020/02/02 12:00:01")!!
+        val customDate3 = dateHelper.createDate(format,"2020/02/02 12:10:59")!!
+        val customDate4 = dateHelper.createDate(format,"2020/02/02 12:11:09")!!
+        val difference12 = dateHelper.getDateDifferenceString(customDate1, customDate2)
+        val difference34 = dateHelper.getDateDifferenceString(customDate3, customDate4)
         assertEquals("1s", difference12)
         assertEquals("10s", difference34)
     }
 
     @Test
     fun getDateDifferenceStringIsCorrectForMinutes() {
-        val customDate1 = DateHelper.createDate("2020/02/02 12:01:00")!!
-        val customDate2 = DateHelper.createDate("2020/02/02 12:05:00")!!
-        val customDate3 = DateHelper.createDate("2020/02/02 12:55:00")!!
-        val customDate4 = DateHelper.createDate("2020/02/02 13:05:00")!!
-        val difference12 = DateHelper.getDateDifferenceString(customDate1, customDate2)
-        val difference34 = DateHelper.getDateDifferenceString(customDate3, customDate4)
+        val customDate1 = dateHelper.createDate(format,"2020/02/02 12:01:00")!!
+        val customDate2 = dateHelper.createDate(format,"2020/02/02 12:05:00")!!
+        val customDate3 = dateHelper.createDate(format,"2020/02/02 12:55:00")!!
+        val customDate4 = dateHelper.createDate(format,"2020/02/02 13:05:00")!!
+        val difference12 = dateHelper.getDateDifferenceString(customDate1, customDate2)
+        val difference34 = dateHelper.getDateDifferenceString(customDate3, customDate4)
         assertEquals("4min", difference12)
         assertEquals("10min", difference34)
     }
 
     @Test
     fun getDateDifferenceStringIsCorrectForHours() {
-        val customDate1 = DateHelper.createDate("2020/02/02 12:00:00")!!
-        val customDate2 = DateHelper.createDate("2020/02/02 13:00:00")!!
-        val customDate3 = DateHelper.createDate("2020/02/02 23:00:00")!!
-        val customDate4 = DateHelper.createDate("2020/02/03 04:00:00")!!
-        val difference12 = DateHelper.getDateDifferenceString(customDate1, customDate2)
-        val difference34 = DateHelper.getDateDifferenceString(customDate3, customDate4)
+        val customDate1 = dateHelper.createDate(format,"2020/02/02 12:00:00")!!
+        val customDate2 = dateHelper.createDate(format,"2020/02/02 13:00:00")!!
+        val customDate3 = dateHelper.createDate(format,"2020/02/02 23:00:00")!!
+        val customDate4 = dateHelper.createDate(format,"2020/02/03 04:00:00")!!
+        val difference12 = dateHelper.getDateDifferenceString(customDate1, customDate2)
+        val difference34 = dateHelper.getDateDifferenceString(customDate3, customDate4)
         assertEquals("1h", difference12)
         assertEquals("5h", difference34)
     }
 
     @Test
     fun getDateDifferenceStringIsCorrectForWeeks() {
-        val customDate1 = DateHelper.createDate("2020/02/02 12:00:00")!!
-        val customDate2 = DateHelper.createDate("2020/02/09 12:00:00")!!
-        val customDate3 = DateHelper.createDate("2020/03/31 12:00:00")!!
-        val customDate4 = DateHelper.createDate("2020/04/07 12:00:00")!!
-        val difference12 = DateHelper.getDateDifferenceString(customDate1, customDate2)
-        val difference34 = DateHelper.getDateDifferenceString(customDate3, customDate4)
+        val customDate1 = dateHelper.createDate(format,"2020/02/02 12:00:00")!!
+        val customDate2 = dateHelper.createDate(format,"2020/02/09 12:00:00")!!
+        val customDate3 = dateHelper.createDate(format,"2020/03/31 12:00:00")!!
+        val customDate4 = dateHelper.createDate(format,"2020/04/07 12:00:00")!!
+        val difference12 = dateHelper.getDateDifferenceString(customDate1, customDate2)
+        val difference34 = dateHelper.getDateDifferenceString(customDate3, customDate4)
         assertEquals("1w", difference12)
         assertEquals("1w", difference34)
     }
 
     @Test
     fun getDateDifferenceStringIsCorrectForMonths() {
-        val customDate1 = DateHelper.createDate("2020/05/02 12:00:00")!!
-        val customDate2 = DateHelper.createDate("2020/06/02 12:00:00")!!
-        val customDate3 = DateHelper.createDate("2020/12/01 12:00:00")!!
-        val customDate4 = DateHelper.createDate("2021/01/01 12:00:00")!!
-        val difference12 = DateHelper.getDateDifferenceString(customDate1, customDate2)
-        val difference34 = DateHelper.getDateDifferenceString(customDate3, customDate4)
+        val customDate1 = dateHelper.createDate(format,"2020/05/02 12:00:00")!!
+        val customDate2 = dateHelper.createDate(format,"2020/06/02 12:00:00")!!
+        val customDate3 = dateHelper.createDate(format,"2020/12/01 12:00:00")!!
+        val customDate4 = dateHelper.createDate(format,"2021/01/01 12:00:00")!!
+        val difference12 = dateHelper.getDateDifferenceString(customDate1, customDate2)
+        val difference34 = dateHelper.getDateDifferenceString(customDate3, customDate4)
         assertEquals("1mon", difference12)
         assertEquals("1mon", difference34)
     }
 
     @Test
     fun getDateDifferenceStringIsCorrectForYears() {
-        val customDate1 = DateHelper.createDate("2020/02/02 12:00:00")!!
-        val customDate2 = DateHelper.createDate("2021/03/02 12:00:00")!!
-        val difference = DateHelper.getDateDifferenceString(customDate1, customDate2)
+        val customDate1 = dateHelper.createDate(format,"2020/02/02 12:00:00")!!
+        val customDate2 = dateHelper.createDate(format,"2021/03/02 12:00:00")!!
+        val difference = dateHelper.getDateDifferenceString(customDate1, customDate2)
         assertEquals("1y", difference)
     }
 }


### PR DESCRIPTION
The item view shows how much time ago the item has been created 
(or updated if it has been updated since its creation).  
It is also shown on the Detailed View.

1. 55 seconds (left) and 2 minutes (right) after the upload. (See more info below the pictures) 
![Webp net-resizeimage (14)](https://user-images.githubusercontent.com/45470351/119216826-3df27680-bad6-11eb-8907-59e43121ac23.png) ![Webp net-resizeimage (15)](https://user-images.githubusercontent.com/45470351/119216827-3df27680-bad6-11eb-8ce2-20c89a3c9426.png)

2. Detailed View: 
![Webp net-resizeimage (16)](https://user-images.githubusercontent.com/45470351/119216871-8316a880-bad6-11eb-8e29-a75ccb185645.png)

The timestamps are seconds, minutes, hours, days, weeks, months and years (shown respectively as 
`s`, `min`, `h`, `d`, `w`, `mon` and `y`). If the item has been posted less than a minute ago, it will show seconds, if the item has been posted more than a minute ago but less than an hour ago, it will show minutes, etc...

Notes:
1. There are some imprecisions in the code concerning the calculations (i.e. a year does not always have 365 days and a month does not always contain 30 days), but as we are using these as estimates for the buyer to have an idea about when the item has last been updated, I think it is fine this way.
2. I cannot make the text or the icon bigger otherwise it will either not show completely, or cover up the item image. 
