### PR TITLE
Message timestamps

### DIFF
--- a/app/src/androidTest/java/com/example/sharingang/ChatTest.kt
+++ b/app/src/androidTest/java/com/example/sharingang/ChatTest.kt
@@ -12,9 +12,11 @@ import com.example.sharingang.utils.navigate_to
 import com.example.sharingang.utils.waitAfterSaveItem
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
+import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.CoreMatchers.not
 import org.junit.Rule
 import org.junit.Test
+import java.util.*
 
 @HiltAndroidTest
 class ChatTest {
@@ -65,6 +67,11 @@ class ChatTest {
         Thread.sleep(1000)
         onView(withId(R.id.btnSend)).perform(click())
         onView(withText(message1)).check(matches(isDisplayed()))
+        val currentDate = Date()
+        val currentHourStr = currentDate.hours.toString()
+        val currentMinStr = currentDate.minutes.toString().padStart(2, '0')
+        val timestamp = "Today, $currentHourStr:$currentMinStr"
+        onView(withId(R.id.message_time)).check(matches(withText(containsString(timestamp))))
         onView(withId(R.id.messageEditText)).check(matches(withText("")))
         onView(withId(R.id.btnSend)).check(matches(not(isEnabled())))
         val message2 = getRandomString(15)

--- a/app/src/main/java/com/example/sharingang/database/cache/CachedUserRepository.kt
+++ b/app/src/main/java/com/example/sharingang/database/cache/CachedUserRepository.kt
@@ -8,6 +8,7 @@ import com.example.sharingang.database.store.UserStore
 import com.example.sharingang.models.Chat
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import java.util.*
 import javax.inject.Inject
 
 /**
@@ -84,8 +85,8 @@ class CachedUserRepository @Inject constructor(
         return store.getMessages(userId, with)
     }
 
-    override suspend fun putMessage(from: String, to: String, message: String): List<Chat> {
-        return store.putMessage(from, to, message)
+    override suspend fun putMessage(from: String, to: String, message: String, date: Date): List<Chat> {
+        return store.putMessage(from, to, message, date)
     }
 
     override suspend fun setupConversationRefresh(

--- a/app/src/main/java/com/example/sharingang/database/firestore/FirestoreUserStore.kt
+++ b/app/src/main/java/com/example/sharingang/database/firestore/FirestoreUserStore.kt
@@ -1,5 +1,6 @@
 package com.example.sharingang.database.firestore
 
+import android.provider.ContactsContract
 import android.util.Log
 import com.example.sharingang.models.User
 import com.example.sharingang.database.store.UserStore
@@ -104,13 +105,13 @@ class FirestoreUserStore @Inject constructor(private val firestore: FirebaseFire
             Chat(
                 it.getString(DatabaseFields.DBFIELD_FROM),
                 it.getString(DatabaseFields.DBFIELD_TO),
-                it.getString(DatabaseFields.DBFIELD_MESSAGE)!!
+                it.getString(DatabaseFields.DBFIELD_MESSAGE)!!,
+                it.getDate(DatabaseFields.DBFIELD_DATE)!!
             )
         }
     }
 
-    override suspend fun putMessage(from: String, to: String, message: String): List<Chat> {
-        val date = Date()
+    override suspend fun putMessage(from: String, to: String, message: String, date: Date): List<Chat> {
         val dataMaps = generateDataMaps(from, to, message, date)
         val data = dataMaps.first
         val lastTimeChatCurrent = dataMaps.second
@@ -189,7 +190,8 @@ class FirestoreUserStore @Inject constructor(private val firestore: FirebaseFire
         val data = hashMapOf<String, Any>(
             DatabaseFields.DBFIELD_MESSAGE to message,
             DatabaseFields.DBFIELD_FROM to from,
-            DatabaseFields.DBFIELD_TO to to
+            DatabaseFields.DBFIELD_TO to to,
+            DatabaseFields.DBFIELD_DATE to date
         )
         val now = System.currentTimeMillis()
         val lastTimeChatCurrent = hashMapOf(

--- a/app/src/main/java/com/example/sharingang/database/repositories/InMemoryUserRepository.kt
+++ b/app/src/main/java/com/example/sharingang/database/repositories/InMemoryUserRepository.kt
@@ -4,6 +4,8 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.example.sharingang.models.Chat
 import com.example.sharingang.models.User
+import java.util.*
+import kotlin.collections.HashMap
 
 /**
  * In-memory implementation of the UserRepository
@@ -80,8 +82,8 @@ class InMemoryUserRepository : UserRepository {
         return mutableListOf()
     }
 
-    override suspend fun putMessage(from: String, to: String, message: String): List<Chat> {
-        val chat = Chat(from, to, message)
+    override suspend fun putMessage(from: String, to: String, message: String, date: Date): List<Chat> {
+        val chat = Chat(from, to, message, date)
         updateMessages(from, to, chat)
         updateChatPartners(from, to)
         updateUnreads(from, to)

--- a/app/src/main/java/com/example/sharingang/database/store/UserStore.kt
+++ b/app/src/main/java/com/example/sharingang/database/store/UserStore.kt
@@ -2,6 +2,7 @@ package com.example.sharingang.database.store
 
 import com.example.sharingang.models.Chat
 import com.example.sharingang.models.User
+import java.util.*
 
 /**
  * Represents a remote store of users, that we can access in some way.
@@ -85,7 +86,7 @@ interface UserStore {
      * @param message the message
      * @return the new list of messages between the two users
      */
-    suspend fun putMessage(from: String, to: String, message: String): List<Chat>
+    suspend fun putMessage(from: String, to: String, message: String, date: Date): List<Chat>
 
     /**
      * Sets up the listener on messages for a particular user with another user

--- a/app/src/main/java/com/example/sharingang/models/Chat.kt
+++ b/app/src/main/java/com/example/sharingang/models/Chat.kt
@@ -1,5 +1,7 @@
 package com.example.sharingang.models
 
+import java.util.*
+
 /**
  * Chat represents a message with additional metadata
  *
@@ -7,4 +9,36 @@ package com.example.sharingang.models
  * @property to the receiver
  * @property message the actual message
  */
-data class Chat(val from: String?, val to: String?, val message: String)
+data class Chat(val from: String?, val to: String?, val message: String, val date: Date) {
+    fun getMessageTime(): String {
+        val currentDate = Date()
+        val today = Triple(currentDate.year, currentDate.month, currentDate.day)
+        val messageTime = Triple(date.year, date.month, date.day)
+        val monthStr = getMonthName(date.month)
+        return (
+                if(today == messageTime) "Today, ${date.hours}:${date.minutes}"
+                else if (today.first == messageTime.first) "$monthStr ${date.day}"
+                else "$monthStr ${date.day}, ${date.year}"
+                )
+    }
+    private fun getMonthName(monthNumber: Int): String {
+        return (
+                when(monthNumber) {
+                    1 -> "January"
+                    2 -> "February"
+                    3 -> "March"
+                    4 -> "April"
+                    5 -> "May"
+                    6 -> "June"
+                    7 -> "July"
+                    8 -> "August"
+                    9 -> "September"
+                    10 -> "October"
+                    11 -> "November"
+                    12 -> "December"
+                    else -> ""
+                }
+                )
+    }
+
+}

--- a/app/src/main/java/com/example/sharingang/models/Chat.kt
+++ b/app/src/main/java/com/example/sharingang/models/Chat.kt
@@ -9,41 +9,4 @@ import java.util.*
  * @property to the receiver
  * @property message the actual message
  */
-data class Chat(val from: String?, val to: String?, val message: String, val date: Date) {
-    fun getMessageTime(): String {
-        val currentDate = Date()
-        val today = Triple(currentDate.year, currentDate.month, currentDate.day)
-        val messageTime = Triple(date.year, date.month, date.day)
-        val monthStr = getMonthName(date.month)
-        return (
-                when {
-                    today == messageTime -> "Today, ${date.hours}:${
-                        if(date.minutes < 10) "0" + "${date.minutes}"
-                        else date.minutes
-                    }"
-                    today.first == messageTime.first -> "$monthStr ${date.day}"
-                    else -> "$monthStr ${date.day}, ${date.year}"
-                }
-                )
-    }
-    private fun getMonthName(monthNumber: Int): String {
-        return (
-                when(monthNumber) {
-                    1 -> "Jan."
-                    2 -> "Feb."
-                    3 -> "Mar."
-                    4 -> "Apr."
-                    5 -> "May."
-                    6 -> "Jun."
-                    7 -> "Jul."
-                    8 -> "Aug."
-                    9 -> "Sep."
-                    10 -> "Oct."
-                    11 -> "Nov."
-                    12 -> "Dec."
-                    else -> ""
-                }
-                )
-    }
-
-}
+data class Chat(val from: String?, val to: String?, val message: String, val date: Date)

--- a/app/src/main/java/com/example/sharingang/models/Chat.kt
+++ b/app/src/main/java/com/example/sharingang/models/Chat.kt
@@ -16,26 +16,31 @@ data class Chat(val from: String?, val to: String?, val message: String, val dat
         val messageTime = Triple(date.year, date.month, date.day)
         val monthStr = getMonthName(date.month)
         return (
-                if(today == messageTime) "Today, ${date.hours}:${date.minutes}"
-                else if (today.first == messageTime.first) "$monthStr ${date.day}"
-                else "$monthStr ${date.day}, ${date.year}"
+                when {
+                    today == messageTime -> "Today, ${date.hours}:${
+                        if(date.minutes < 10) "0" + "${date.minutes}"
+                        else date.minutes
+                    }"
+                    today.first == messageTime.first -> "$monthStr ${date.day}"
+                    else -> "$monthStr ${date.day}, ${date.year}"
+                }
                 )
     }
     private fun getMonthName(monthNumber: Int): String {
         return (
                 when(monthNumber) {
-                    1 -> "January"
-                    2 -> "February"
-                    3 -> "March"
-                    4 -> "April"
-                    5 -> "May"
-                    6 -> "June"
-                    7 -> "July"
-                    8 -> "August"
-                    9 -> "September"
-                    10 -> "October"
-                    11 -> "November"
-                    12 -> "December"
+                    1 -> "Jan."
+                    2 -> "Feb."
+                    3 -> "Mar."
+                    4 -> "Apr."
+                    5 -> "May."
+                    6 -> "Jun."
+                    7 -> "Jul."
+                    8 -> "Aug."
+                    9 -> "Sep."
+                    10 -> "Oct."
+                    11 -> "Nov."
+                    12 -> "Dec."
                     else -> ""
                 }
                 )

--- a/app/src/main/java/com/example/sharingang/ui/adapters/MessageAdapter.kt
+++ b/app/src/main/java/com/example/sharingang/ui/adapters/MessageAdapter.kt
@@ -9,6 +9,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.example.sharingang.R
 import com.example.sharingang.models.Chat
 import com.example.sharingang.ui.fragments.MessageFragment
+import com.example.sharingang.utils.DateHelper
 
 /**
  * MessageAdapter takes care of adapting a list of messages into a Recycler View.
@@ -56,7 +57,7 @@ class MessageAdapter(
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         val message: String = chats[position].message
         holder.text.text = message
-        holder.time.text = chats[position].getMessageTime()
+        holder.time.text = DateHelper.formatMessageDate(chats[position].date)
     }
 
     override fun getItemCount(): Int {

--- a/app/src/main/java/com/example/sharingang/ui/adapters/MessageAdapter.kt
+++ b/app/src/main/java/com/example/sharingang/ui/adapters/MessageAdapter.kt
@@ -19,7 +19,7 @@ import com.example.sharingang.utils.DateHelper
  * @property currentUserId the current logged in user's id
  */
 class MessageAdapter(
-    private val context: Context, private var chats: List<Chat>,
+    private val context: Context, private var chats: MutableList<Chat>,
     private val currentUserId: String, private val attachedFragment: MessageFragment
 ) :
     RecyclerView.Adapter<MessageAdapter.ViewHolder>() {
@@ -78,7 +78,8 @@ class MessageAdapter(
      * @param newData the incoming data
      */
     fun submitList(newData: List<Chat>) {
-        chats = newData
+        chats.clear()
+        chats.addAll(newData)
         notifyDataSetChanged()
         attachedFragment.scrollToEnd()
     }

--- a/app/src/main/java/com/example/sharingang/ui/adapters/MessageAdapter.kt
+++ b/app/src/main/java/com/example/sharingang/ui/adapters/MessageAdapter.kt
@@ -18,7 +18,7 @@ import com.example.sharingang.ui.fragments.MessageFragment
  * @property currentUserId the current logged in user's id
  */
 class MessageAdapter(
-    private val context: Context, private var chats: MutableList<Chat>,
+    private val context: Context, private var chats: List<Chat>,
     private val currentUserId: String, private val attachedFragment: MessageFragment
 ) :
     RecyclerView.Adapter<MessageAdapter.ViewHolder>() {
@@ -39,6 +39,7 @@ class MessageAdapter(
      */
     class ViewHolder(messageEntryView: View) : RecyclerView.ViewHolder(messageEntryView) {
         var text: TextView = messageEntryView.findViewById(R.id.messageText)
+        var time: TextView = messageEntryView.findViewById(R.id.message_time)
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
@@ -55,6 +56,7 @@ class MessageAdapter(
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         val message: String = chats[position].message
         holder.text.text = message
+        holder.time.text = chats[position].getMessageTime()
     }
 
     override fun getItemCount(): Int {
@@ -75,8 +77,7 @@ class MessageAdapter(
      * @param newData the incoming data
      */
     fun submitList(newData: List<Chat>) {
-        chats.clear()
-        chats.addAll(newData)
+        chats = newData
         notifyDataSetChanged()
         attachedFragment.scrollToEnd()
     }

--- a/app/src/main/java/com/example/sharingang/ui/adapters/MessageAdapter.kt
+++ b/app/src/main/java/com/example/sharingang/ui/adapters/MessageAdapter.kt
@@ -55,9 +55,10 @@ class MessageAdapter(
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        val dateHelper = DateHelper(context)
         val message: String = chats[position].message
         holder.text.text = message
-        holder.time.text = DateHelper.formatMessageDate(chats[position].date)
+        holder.time.text = dateHelper.formatMessageDate(chats[position].date)
     }
 
     override fun getItemCount(): Int {

--- a/app/src/main/java/com/example/sharingang/utils/DateHelper.kt
+++ b/app/src/main/java/com/example/sharingang/utils/DateHelper.kt
@@ -1,22 +1,24 @@
 package com.example.sharingang.utils
 
+import android.content.Context
+import com.example.sharingang.R
 import java.util.*
 
-object DateHelper {
+class DateHelper(context: Context) {
 
     private val monthsMap = hashMapOf(
-        0 to "Jan",
-        1 to "Feb",
-        2 to "Mar",
-        3 to "Apr",
-        4 to "May",
-        5 to "Jun",
-        6 to "Jul",
-        7 to "Aug",
-        8 to "Sep",
-        9 to "Oct",
-        10 to "Nov",
-        11 to "Dec"
+        0 to context.resources.getString(R.string.eng_jan),
+        1 to context.resources.getString(R.string.eng_feb),
+        2 to context.resources.getString(R.string.eng_mar),
+        3 to context.resources.getString(R.string.eng_apr),
+        4 to context.resources.getString(R.string.eng_may),
+        5 to context.resources.getString(R.string.eng_jun),
+        6 to context.resources.getString(R.string.eng_jul),
+        7 to context.resources.getString(R.string.eng_aug),
+        8 to context.resources.getString(R.string.eng_sep),
+        9 to context.resources.getString(R.string.eng_oct),
+        10 to context.resources.getString(R.string.eng_nov),
+        11 to context.resources.getString(R.string.eng_dec),
     )
 
     /**

--- a/app/src/main/java/com/example/sharingang/utils/DateHelper.kt
+++ b/app/src/main/java/com/example/sharingang/utils/DateHelper.kt
@@ -4,6 +4,21 @@ import java.util.*
 
 object DateHelper {
 
+    private val monthsMap = hashMapOf(
+        0 to "Jan",
+        1 to "Feb",
+        2 to "Mar",
+        3 to "Apr",
+        4 to "May",
+        5 to "Jun",
+        6 to "Jul",
+        7 to "Aug",
+        8 to "Sep",
+        9 to "Oct",
+        10 to "Nov",
+        11 to "Dec"
+    )
+
     /**
      * formats a date for message timestamps
      *
@@ -14,40 +29,14 @@ object DateHelper {
         val currentDate = Date()
         val today = Triple(currentDate.year, currentDate.month, currentDate.day)
         val messageTime = Triple(date.year, date.month, date.day)
-        val monthStr = getMonthName(date.month)
+        val monthStr = monthsMap[date.month]
         return (
             when {
                 today == messageTime -> "Today, ${date.hours}:${
                     date.minutes.toString().padStart(2, '0')
                 }"
-                today.first == messageTime.first -> "$monthStr ${date.day}"
-                else -> "$monthStr ${date.day}, ${date.year}"
-            }
-        )
-    }
-
-    /**
-     * get the name of the month based on its integer value
-     *
-     * @param monthNumber the number of the month we want to get the name of
-     * @return the name of the month
-     */
-    private fun getMonthName(monthNumber: Int): String {
-        return (
-            when(monthNumber) {
-                0 -> "Jan."
-                1 -> "Feb."
-                2 -> "Mar."
-                3 -> "Apr."
-                4 -> "May."
-                5 -> "Jun."
-                6 -> "Jul."
-                7 -> "Aug."
-                8 -> "Sep."
-                9 -> "Oct."
-                10 -> "Nov."
-                11 -> "Dec."
-                else -> ""
+                today.first == messageTime.first -> "$monthStr. ${date.day}"
+                else -> "$monthStr. ${date.day}, ${date.year}"
             }
         )
     }

--- a/app/src/main/java/com/example/sharingang/utils/DateHelper.kt
+++ b/app/src/main/java/com/example/sharingang/utils/DateHelper.kt
@@ -1,48 +1,56 @@
 package com.example.sharingang.utils
 
 import java.util.*
-import java.util.concurrent.TimeUnit
 
 object DateHelper {
-    fun getDateDifferenceInDays(startDate: Date, endDate: Date): Long {
-        return TimeUnit.DAYS.convert(endDate.time - startDate.time,
-            TimeUnit.MILLISECONDS)
-    }
 
+    /**
+     * formats a date for message timestamps
+     *
+     * @param date the date to format
+     * @return the formatted date
+     */
     fun formatMessageDate(date: Date): String {
         val currentDate = Date()
         val today = Triple(currentDate.year, currentDate.month, currentDate.day)
         val messageTime = Triple(date.year, date.month, date.day)
         val monthStr = getMonthName(date.month)
         return (
-                when {
-                    today == messageTime -> "Today, ${date.hours}:${
-                        if(date.minutes < 10) "0" + "${date.minutes}"
-                        else date.minutes
-                    }"
-                    today.first == messageTime.first -> "$monthStr ${date.day}"
-                    else -> "$monthStr ${date.day}, ${date.year}"
-                }
-                )
+            when {
+                today == messageTime -> "Today, ${date.hours}:${
+                    date.minutes.toString().padStart(2, '0')
+                }"
+                today.first == messageTime.first -> "$monthStr ${date.day}"
+                else -> "$monthStr ${date.day}, ${date.year}"
+            }
+        )
     }
+
+    /**
+     * get the name of the month based on its integer value in real life (i.e. 1 is equivalent
+     * to January, not February)
+     *
+     * @param monthNumber the number of the month we want to get the name of
+     * @return the name of the month
+     */
     private fun getMonthName(monthNumber: Int): String {
         return (
-                when(monthNumber) {
-                    1 -> "Jan."
-                    2 -> "Feb."
-                    3 -> "Mar."
-                    4 -> "Apr."
-                    5 -> "May."
-                    6 -> "Jun."
-                    7 -> "Jul."
-                    8 -> "Aug."
-                    9 -> "Sep."
-                    10 -> "Oct."
-                    11 -> "Nov."
-                    12 -> "Dec."
-                    else -> ""
-                }
-                )
+            when(monthNumber) {
+                1 -> "Jan."
+                2 -> "Feb."
+                3 -> "Mar."
+                4 -> "Apr."
+                5 -> "May."
+                6 -> "Jun."
+                7 -> "Jul."
+                8 -> "Aug."
+                9 -> "Sep."
+                10 -> "Oct."
+                11 -> "Nov."
+                12 -> "Dec."
+                else -> ""
+            }
+        )
     }
 
 }

--- a/app/src/main/java/com/example/sharingang/utils/DateHelper.kt
+++ b/app/src/main/java/com/example/sharingang/utils/DateHelper.kt
@@ -36,18 +36,18 @@ object DateHelper {
     private fun getMonthName(monthNumber: Int): String {
         return (
             when(monthNumber) {
-                1 -> "Jan."
-                2 -> "Feb."
-                3 -> "Mar."
-                4 -> "Apr."
-                5 -> "May."
-                6 -> "Jun."
-                7 -> "Jul."
-                8 -> "Aug."
-                9 -> "Sep."
-                10 -> "Oct."
-                11 -> "Nov."
-                12 -> "Dec."
+                0 -> "Jan."
+                1 -> "Feb."
+                2 -> "Mar."
+                3 -> "Apr."
+                4 -> "May."
+                5 -> "Jun."
+                6 -> "Jul."
+                7 -> "Aug."
+                8 -> "Sep."
+                9 -> "Oct."
+                10 -> "Nov."
+                11 -> "Dec."
                 else -> ""
             }
         )

--- a/app/src/main/java/com/example/sharingang/utils/DateHelper.kt
+++ b/app/src/main/java/com/example/sharingang/utils/DateHelper.kt
@@ -4,7 +4,11 @@ import android.content.Context
 import com.example.sharingang.R
 import java.util.*
 
-class DateHelper(context: Context) {
+/**
+ * Helper for date calculations and date/time formatting
+ * @property context the context
+ */
+class DateHelper(private val context: Context) {
 
     private val monthsMap = hashMapOf(
         0 to context.resources.getString(R.string.eng_jan),
@@ -34,9 +38,10 @@ class DateHelper(context: Context) {
         val monthStr = monthsMap[date.month]
         return (
             when {
-                today == messageTime -> "Today, ${date.hours}:${
-                    date.minutes.toString().padStart(2, '0')
-                }"
+                today == messageTime -> context.getString(R.string.eng_today,
+                    ", ${date.hours}:${date.minutes.toString()
+                        .padStart(2, '0')}"
+                )
                 today.first == messageTime.first -> "$monthStr. ${date.day}"
                 else -> "$monthStr. ${date.day}, ${date.year}"
             }

--- a/app/src/main/java/com/example/sharingang/utils/DateHelper.kt
+++ b/app/src/main/java/com/example/sharingang/utils/DateHelper.kt
@@ -1,0 +1,48 @@
+package com.example.sharingang.utils
+
+import java.util.*
+import java.util.concurrent.TimeUnit
+
+object DateHelper {
+    fun getDateDifferenceInDays(startDate: Date, endDate: Date): Long {
+        return TimeUnit.DAYS.convert(endDate.time - startDate.time,
+            TimeUnit.MILLISECONDS)
+    }
+
+    fun formatMessageDate(date: Date): String {
+        val currentDate = Date()
+        val today = Triple(currentDate.year, currentDate.month, currentDate.day)
+        val messageTime = Triple(date.year, date.month, date.day)
+        val monthStr = getMonthName(date.month)
+        return (
+                when {
+                    today == messageTime -> "Today, ${date.hours}:${
+                        if(date.minutes < 10) "0" + "${date.minutes}"
+                        else date.minutes
+                    }"
+                    today.first == messageTime.first -> "$monthStr ${date.day}"
+                    else -> "$monthStr ${date.day}, ${date.year}"
+                }
+                )
+    }
+    private fun getMonthName(monthNumber: Int): String {
+        return (
+                when(monthNumber) {
+                    1 -> "Jan."
+                    2 -> "Feb."
+                    3 -> "Mar."
+                    4 -> "Apr."
+                    5 -> "May."
+                    6 -> "Jun."
+                    7 -> "Jul."
+                    8 -> "Aug."
+                    9 -> "Sep."
+                    10 -> "Oct."
+                    11 -> "Nov."
+                    12 -> "Dec."
+                    else -> ""
+                }
+                )
+    }
+
+}

--- a/app/src/main/java/com/example/sharingang/utils/DateHelper.kt
+++ b/app/src/main/java/com/example/sharingang/utils/DateHelper.kt
@@ -27,8 +27,7 @@ object DateHelper {
     }
 
     /**
-     * get the name of the month based on its integer value in real life (i.e. 1 is equivalent
-     * to January, not February)
+     * get the name of the month based on its integer value
      *
      * @param monthNumber the number of the month we want to get the name of
      * @return the name of the month
@@ -52,5 +51,4 @@ object DateHelper {
             }
         )
     }
-
 }

--- a/app/src/main/java/com/example/sharingang/utils/constants/DatabaseFields.kt
+++ b/app/src/main/java/com/example/sharingang/utils/constants/DatabaseFields.kt
@@ -6,6 +6,7 @@ package com.example.sharingang.utils.constants
  */
 interface DatabaseFields {
     companion object {
+        const val DBFIELD_DATE = "date"
         const val DBFIELD_NUM_UNREAD = "numUnread"
         const val DBFIELD_MESSAGE = "message"
         const val DBFIELD_FROM = "from"

--- a/app/src/main/res/layout/message_entry_left.xml
+++ b/app/src/main/res/layout/message_entry_left.xml
@@ -1,17 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="300dp"
     android:padding="8dp"
     android:layout_height="wrap_content">
 
-    <TextView
-        android:id="@+id/messageText"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="5dp"
-        android:padding="8dp"
-        android:text="@string/message"
-        android:textColor="@color/white"
-        android:background="@drawable/msg_bg_left"/>
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <TextView
+            android:id="@+id/messageText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="@drawable/msg_bg_left"
+            android:padding="8dp"
+            android:text="@string/message"
+            android:textColor="@color/white"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/message_time"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="5dp"
+            android:text="@string/message_time"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/messageText" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
 </RelativeLayout>

--- a/app/src/main/res/layout/message_entry_right.xml
+++ b/app/src/main/res/layout/message_entry_right.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="375dp"
     android:padding="8dp"
@@ -7,14 +8,28 @@
     android:layout_height="wrap_content"
     tools:ignore="RtlSymmetry">
 
-    <TextView
-        android:id="@+id/messageText"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:background="@drawable/msg_bg_right"
-        android:layout_marginStart="5dp"
-        android:text="@string/message"
-        android:layout_alignParentEnd="true"
-        android:textColor="@color/white"
-        android:padding="10dp"/>
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <TextView
+            android:id="@+id/messageText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="@drawable/msg_bg_right"
+            android:padding="10dp"
+            android:text="@string/message"
+            android:textColor="@color/white"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/message_time"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="10dp"
+            android:text="@string/message_time"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/messageText" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -99,4 +99,5 @@
     <string name="open_camera">Open Camera</string>
     <string name="is_discount">Discount?</string>
     <string name="discount_lower">Discount price must be lower</string>
+    <string name="message_time">Time</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -112,4 +112,5 @@
     <string name="eng_oct">Oct</string>
     <string name="eng_nov">Nov</string>
     <string name="eng_dec">Dec</string>
+    <string name="eng_today">Today%s</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -100,4 +100,16 @@
     <string name="is_discount">Discount?</string>
     <string name="discount_lower">Discount price must be lower</string>
     <string name="message_time">Time</string>
+    <string name="eng_jan">Jan</string>
+    <string name="eng_feb">Feb</string>
+    <string name="eng_mar">Mar</string>
+    <string name="eng_apr">Apr</string>
+    <string name="eng_may">May</string>
+    <string name="eng_jun">Jun</string>
+    <string name="eng_jul">Jul</string>
+    <string name="eng_aug">Aug</string>
+    <string name="eng_sep">Sep</string>
+    <string name="eng_oct">Oct</string>
+    <string name="eng_nov">Nov</string>
+    <string name="eng_dec">Dec</string>
 </resources>


### PR DESCRIPTION
Messages have now timestamps (more information below the picture).

![Webp net-resizeimage (13)](https://user-images.githubusercontent.com/45470351/119215329-498d6f80-bacd-11eb-9457-2be4dcf63390.png)

If a message has been sent today, it will have `Today, hh:mm` as timestamp. Ex: `Today, 12:03` 
(If the hour is less than 10, we just have `h:mm`)
If a message has been sent this year but not today, it will have `monthName. dd` as timestamp. Ex: `Feb. 2` 
Otherwise, it will have `monthName. dd, yyyy` as timestamp. Ex: `Mar. 12, 2020`

Where

`monthName` corresponds to the first 3 letters of the month in question. We don't want too much text under the message, it should just be an indicator, due to which 3 letters are fine in my opinion.
