### PR TITLE
Remove useless image access from detailed view

### DIFF
--- a/app/src/main/java/com/example/sharingang/ui/fragments/DetailedItemFragment.kt
+++ b/app/src/main/java/com/example/sharingang/ui/fragments/DetailedItemFragment.kt
@@ -53,13 +53,9 @@ class DetailedItemFragment : Fragment() {
     private lateinit var binding: FragmentDetailedItemBinding
     private var item: Item? = null
 
-    private lateinit var observer: ImageAccess
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setHasOptionsMenu(true)
-        observer = ImageAccess(requireActivity())
-        lifecycle.addObserver(observer)
         paymentProvider.initialize(this, requireContext())
     }
 
@@ -71,7 +67,6 @@ class DetailedItemFragment : Fragment() {
             DataBindingUtil.inflate(inflater, R.layout.fragment_detailed_item, container, false)
         val itemId = args.item.id!!
         lifecycleScope.launch(Dispatchers.IO) { loadItem(itemId) }
-        observer.setupImageView(binding.detailedItemImage)
         args.item.image?.let {
             Glide.with(this).load(it).into(binding.detailedItemImage)
         }


### PR DESCRIPTION
Fixes #278 
The image access in the detailed view was useless but since it was registering in detailed, when navigating to edit, the callbacks would only launch on the detailed view.