### PR TITLE
Fix detection if image was already uploaded

### DIFF
--- a/app/src/main/java/com/example/sharingang/viewmodels/ItemsViewModel.kt
+++ b/app/src/main/java/com/example/sharingang/viewmodels/ItemsViewModel.kt
@@ -101,7 +101,7 @@ class ItemsViewModel @Inject constructor(
     fun setItem(item: Item, callback: ((String?) -> Unit)? = null) {
         viewModelScope.launch(Dispatchers.IO) {
             val uploadUrl = item.image?.let {
-                if (!it.startsWith("https://")) {
+                if (!it.startsWith("https://") && !it.startsWith("http://")) {
                     imageStore.store(it.toUri())?.toString()
                 } else {
                     it


### PR DESCRIPTION
@v1ruso found this bug
When editing an item with an existing image, it doesn't detect that the image was already uploaded when using Firebase Storage emulator.